### PR TITLE
SqliteContext

### DIFF
--- a/lib/contexts/Context.js
+++ b/lib/contexts/Context.js
@@ -19,6 +19,43 @@ class Context {
     }
   }
 
+  createExpr (expr, lang = null) {
+    if (typeof expr === 'string' || expr instanceof String) {
+      expr = {
+        source: {
+          type: 'text',
+          lang: lang,
+          data: expr
+        }
+      }
+    }
+    if (expr.type !== 'expr') expr.type = 'expr'
+    if (!expr.source) expr.source = {type: 'text', data: ''}
+    if (!expr.inputs) expr.inputs = []
+    if (!expr.output) expr.output = {}
+    if (!expr.messages) expr.messages = []
+    return expr
+  }
+
+  createBlock (block, lang = null) {
+    if (typeof block === 'string' || block instanceof String) {
+      block = {
+        type: 'block',
+        source: {
+          type: 'text',
+          lang: lang,
+          data: block
+        }
+      }
+    }
+    if (block.type !== 'block') block.type = 'block'
+    if (!block.source) block.source = {type: 'text', data: ''}
+    if (!block.inputs) block.inputs = []
+    if (!block.output) block.output = {}
+    if (!block.messages) block.messages = []
+    return block
+  }
+
   compile (node) {
 
   }

--- a/lib/contexts/Context.js
+++ b/lib/contexts/Context.js
@@ -6,6 +6,19 @@ class Context {
     }
   }
 
+  /**
+   * Unpack a data node into a native data value
+   *
+   * @param  {Object} node A data node (either a data packet or data pointer)
+   * @return {[type]}      [description]
+   */
+  unpack (node) {
+    const type = node.type
+    switch (type) {
+      default: return node.data
+    }
+  }
+
   compile (node) {
 
   }

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -1,0 +1,77 @@
+const assert = require('assert')
+const sqlite3 = require('sqlite3').verbose()
+const sqliteParser = require('sqlite-parser')
+
+const Context = require('./Context')
+
+class SqliteContext extends Context {
+  constructor () {
+    super()
+
+    let db = ':memory:'
+    this._db = new sqlite3.Database(db)
+  }
+
+  compileExpr (node) {
+    return Promise.resolve().then(() => {
+      let sql
+      if (typeof node === 'string' || node instanceof String) {
+        sql = node
+      } else {
+        assert(node.source, 'Expression must have a `source` property')
+        if (node.source.lang) assert.ok(node.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
+        sql = node.source.data
+      }
+
+      let inputs = []
+      let messages = []
+
+      // Get all variable interpolation inputs and replace them prior to parsing e.g. `${x}` by `0`
+      sql = sql.replace(/\${([^{}]*)}/g, function (match, group1) {
+        inputs.push(group1)
+        return '0'
+      })
+
+      // Check that the expression is a single, SELECT statement
+      const ast = sqliteParser(sql)
+      assert(ast, 'Expression could not be parsed')
+      assert(ast.statement.length === 1 && ast.statement[0].variant === 'select', 'Expression must be a single SELECT statement')
+
+      // Get table inputs by filtering the AST
+      const search = (object) => {
+        if (object.type === 'identifier' && object.variant === 'table') {
+          inputs.push(object.name)
+        } else if (typeof object === 'object') {
+          for (const property of Object.values(object)) {
+            search(property)
+          }
+        }
+      }
+      search(ast.statement[0])
+
+      return { messages, inputs }
+    }).catch((error) => {
+      let line
+      let column
+      if (error.location) {
+        line = error.location.start.line - 1
+        column = error.location.start.column - 1
+      }
+      return {
+        messages: [{
+          type: 'error',
+          message: error.message,
+          line,
+          column
+        }]
+      }
+    })
+  }
+}
+
+SqliteContext.spec = {
+  name: 'SqliteContext',
+  client: 'ContextHttpClient'
+}
+
+module.exports = SqliteContext

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -26,23 +26,23 @@ class SqliteContext extends Context {
    *
    * @override
    */
-  compileExpr (node) {
+  compileExpr (expr) {
     return Promise.resolve().then(() => {
-      if (typeof node === 'string' || node instanceof String) {
-        node = {
+      if (typeof expr === 'string' || expr instanceof String) {
+        expr = {
           type: 'expr',
           source: {
             type: 'text',
             lang: 'sql',
-            data: node
+            data: expr
           }
         }
       } else {
-        assert(node.source, 'Expression must have a `source` property')
-        if (node.source.lang) assert.ok(node.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
+        assert(expr.source, 'Expression must have a `source` property')
+        if (expr.source.lang) assert.ok(expr.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
       }
 
-      let sql = node.source.data
+      let sql = expr.source.data
       let inputs = []
       let output = null
       let messages = []
@@ -62,13 +62,13 @@ class SqliteContext extends Context {
         return {name}
       })
 
-      return Object.assign(node, {
+      return Object.assign(expr, {
         inputs,
         output,
         messages
       })
     }).catch((error) => {
-      return this._handleError(error, node)
+      return this._handleError(error, expr)
     })
   }
 
@@ -83,23 +83,23 @@ class SqliteContext extends Context {
    *
    * @override
    */
-  compileBlock (node) {
+  compileBlock (block) {
     return Promise.resolve().then(() => {
-      if (typeof node === 'string' || node instanceof String) {
-        node = {
+      if (typeof block === 'string' || block instanceof String) {
+        block = {
           type: 'block',
           source: {
             type: 'text',
             lang: 'sql',
-            data: node
+            data: block
           }
         }
       } else {
-        assert(node.source, 'Expression must have a `source` property')
-        if (node.source.lang) assert.ok(node.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
+        assert(block.source, 'Expression must have a `source` property')
+        if (block.source.lang) assert.ok(block.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
       }
 
-      let sql = node.source.data
+      let sql = block.source.data
 
       let inputs = []
       let output = null
@@ -154,13 +154,13 @@ class SqliteContext extends Context {
         return {name}
       })
 
-      return Object.assign(node, {
+      return Object.assign(block, {
         inputs,
         output,
         messages
       })
     }).catch((error) => {
-      return this._handleError(error, node)
+      return this._handleError(error, block)
     })
   }
 
@@ -169,30 +169,30 @@ class SqliteContext extends Context {
    *
    * @override
    */
-  executeExpr (node) {
+  executeExpr (expr) {
     return Promise.resolve().then(() => {
-      // If necessary compile the node
-      if (typeof node === 'string' || node instanceof String || !node.inputs) {
-        return this.compileExpr(node).then((compiled) => {
+      // If necessary compile the expr
+      if (typeof expr === 'string' || expr instanceof String || !expr.inputs) {
+        return this.compileExpr(expr).then((compiled) => {
           return this.executeExpr(compiled)
         })
       }
       // Unpack inputs
       let inputs = {}
-      for (let input of node.inputs) {
+      for (let input of expr.inputs) {
         let {name, value} = this._unpackInput(input)
         inputs[name] = value
       }
       // Do variable interpolation
-      let sql = node.source.data
+      let sql = expr.source.data
       let interp = this._interpolateSql(sql, inputs)
       // Execute SQL
       const rows = this._db.prepare(interp.sql).all()
       // Create a data frame from the rows
-      node.output = {value: this._packTable(rows)}
-      return node
+      expr.output = {value: this._packTable(rows)}
+      return expr
     }).catch((error) => {
-      return this._handleError(error, node)
+      return this._handleError(error, expr)
     })
   }
 

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -129,11 +129,8 @@ class SqliteContext extends Context {
       let inputs = this._unpackInputs(expr.inputs)
       let interp = this._interpolateSql(expr.source.data, inputs)
 
-      // Execute SQL
-      const rows = this._db.prepare(interp.sql).all()
-
-      // Convert the result rows into a data table
-      expr.output.value = this._packTable(rows)
+      // Pack the SELECT statement into an output
+      expr.output = this._packOutput(expr.output, interp.sql)
 
       return expr
     }).catch((error) => {
@@ -167,15 +164,21 @@ class SqliteContext extends Context {
           prepared.run()
         }
       }
-      let rows = this._db.prepare(statements[statements.length - 1]).all()
 
-      // Convert the result rows into a data table
-      block.output.value = this._packTable(rows)
+      // Pack the last statement into an output (if any)
+      let last = statements[statements.length - 1]
+      block.output = this._packOutput(block.output, last)
 
       return block
     }).catch((error) => {
       return this._appendError(block, error)
     })
+  }
+
+  list () {
+    return Promise.resolve(
+      this._db.prepare('SELECT substr(name,8) FROM sqlite_temp_master WHERE type=="table" AND name LIKE "output-%"').pluck().all()
+    )
   }
 
   /**
@@ -292,6 +295,19 @@ class SqliteContext extends Context {
       return {name, value: ''}
     } else {
       return {name, value: this.unpack(value)}
+    }
+  }
+
+  _packOutput (output, select) {
+    if (output.name) {
+      let table = `output-${output.name}`
+      this._db.exec(`DROP TABLE IF EXISTS "${table}"`)
+      this._db.exec(`CREATE TEMPORARY TABLE "${table}" AS ${select}`)
+      let rows = this._db.prepare(select).all()
+      return {name: output.name, value: this._packTable(rows)}
+    } else {
+      let rows = this._db.prepare(select).all()
+      return {value: this._packTable(rows)}
     }
   }
 

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -58,6 +58,7 @@ class SqliteContext extends Context {
       // Get table inputs
       return this._tableInputs(ast).then(tables => {
         inputs = inputs.concat(tables)
+        inputs.sort()
 
         return Object.assign(node, {
           messages,
@@ -147,6 +148,7 @@ class SqliteContext extends Context {
       // Get table inputs
       return this._tableInputs(ast).then(tables => {
         inputs = inputs.concat(tables)
+        inputs.sort()
 
         return Object.assign(node, {
           messages,

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -28,47 +28,31 @@ class SqliteContext extends Context {
    */
   compileExpr (expr) {
     return Promise.resolve().then(() => {
-      if (typeof expr === 'string' || expr instanceof String) {
-        expr = {
-          type: 'expr',
-          source: {
-            type: 'text',
-            lang: 'sql',
-            data: expr
-          }
-        }
-      } else {
-        assert(expr.source, 'Expression must have a `source` property')
-        if (expr.source.lang) assert.ok(expr.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
+      expr = this.createExpr(expr, 'sql')
+      if (expr.source.lang) {
+        assert.ok(expr.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
       }
 
-      let sql = expr.source.data
-      let inputs = []
-      let output = null
-      let messages = []
-
-      // Get interpolation inputs and interpolated SQL
-      let interp = this._interpolateSql(sql)
-      inputs = inputs.concat(interp.variables)
+      // Get interpolation input names and interpolated SQL
+      let interp = this._interpolateSql(expr.source.data)
 
       // Check that the expression is a single, SELECT statement
       const ast = this._parseSql(interp.sql)
       assert(ast.statement.length === 1, 'Expression must be a single "SELECT" statement')
       assert(ast.statement[0].variant === 'select', `Expression must be a "SELECT" statement, "${ast.statement[0].variant.toUpperCase()}" not allowed`)
 
-      // Get table inputs
+      // Get table input names
       const tables = this._tableInputs(ast)
-      inputs = inputs.concat(tables).sort().map(name => {
+
+      // Set expr input array
+      let inputs = interp.variables.concat(tables)
+      expr.inputs = inputs.sort().map(name => {
         return {name}
       })
 
-      return Object.assign(expr, {
-        inputs,
-        output,
-        messages
-      })
+      return expr
     }).catch((error) => {
-      return this._handleError(error, expr)
+      return this._appendError(expr, error)
     })
   }
 
@@ -85,46 +69,16 @@ class SqliteContext extends Context {
    */
   compileBlock (block) {
     return Promise.resolve().then(() => {
-      if (typeof block === 'string' || block instanceof String) {
-        block = {
-          type: 'block',
-          source: {
-            type: 'text',
-            lang: 'sql',
-            data: block
-          }
-        }
-      } else {
-        assert(block.source, 'Expression must have a `source` property')
-        if (block.source.lang) assert.ok(block.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
+      block = this.createBlock(block, 'sql')
+      if (block.source.lang) {
+        assert.ok(block.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
       }
-
-      let sql = block.source.data
-
-      let inputs = []
-      let output = null
-      let messages = []
 
       // Determine block output, if any
-      let outputs = []
-      sql = sql.replace(/^(\s*(\w+)\s*=\s*)\b(SELECT\b.+)/mg, function (match, group1, group2, group3) {
-        outputs.push({
-          name: group2,
-          expr: group3
-        })
-        // Insert spaces so that error reporting location is correct
-        return ' '.repeat(group1.length) + group3
-      })
-      if (outputs.length === 1) {
-        output = {name: outputs[0].name}
-      } else if (outputs.length > 1) {
-        let names = outputs.map(output => output.name).join(', ')
-        throw new Error(`Block must have only one output but ${outputs.length} found "${names}"`)
-      }
+      let {output, sql} = this._transpileSql(block.source.data)
 
       // Get interpolation inputs and interpolated SQL
       let interp = this._interpolateSql(sql)
-      inputs = inputs.concat(interp.variables)
 
       // Parse the intepolated SQL
       const ast = this._parseSql(interp.sql)
@@ -142,7 +96,7 @@ class SqliteContext extends Context {
       }
       search(ast)
       if (effects.length) {
-        messages.push({
+        block.messages.push({
           type: 'warning',
           message: `Block has potential side effects caused by using "${effects.join(', ')}" statements`
         })
@@ -150,17 +104,17 @@ class SqliteContext extends Context {
 
       // Get table inputs
       const tables = this._tableInputs(ast)
-      inputs = inputs.concat(tables).sort().map(name => {
+
+      // Set the block's inputs and output
+      let inputs = interp.variables.concat(tables)
+      block.inputs = inputs.sort().map(name => {
         return {name}
       })
+      if (output) block.output.name = output
 
-      return Object.assign(block, {
-        inputs,
-        output,
-        messages
-      })
+      return block
     }).catch((error) => {
-      return this._handleError(error, block)
+      return this._appendError(block, error)
     })
   }
 
@@ -171,42 +125,84 @@ class SqliteContext extends Context {
    */
   executeExpr (expr) {
     return Promise.resolve().then(() => {
-      // If necessary compile the expr
-      if (typeof expr === 'string' || expr instanceof String || !expr.inputs) {
-        return this.compileExpr(expr).then((compiled) => {
-          return this.executeExpr(compiled)
-        })
-      }
-      // Unpack inputs
-      let inputs = {}
-      for (let input of expr.inputs) {
-        let {name, value} = this._unpackInput(input)
-        inputs[name] = value
-      }
-      // Do variable interpolation
-      let sql = expr.source.data
-      let interp = this._interpolateSql(sql, inputs)
+      // Unpack inputs and do interpolation
+      let inputs = this._unpackInputs(expr.inputs)
+      let interp = this._interpolateSql(expr.source.data, inputs)
+
       // Execute SQL
       const rows = this._db.prepare(interp.sql).all()
-      // Create a data frame from the rows
-      expr.output = {value: this._packTable(rows)}
+
+      // Convert the result rows into a data table
+      expr.output.value = this._packTable(rows)
+
       return expr
     }).catch((error) => {
-      return this._handleError(error, expr)
+      return this._appendError(expr, error)
     })
   }
 
   /**
-   * Do string interpolation of variable in SQL code
+   * Execute a `block` node
+   *
+   * @override
+   */
+  executeBlock (block) {
+    return Promise.resolve().then(() => {
+      // Unpack inputs and do transilation and interpolation
+      let inputs = this._unpackInputs(block.inputs)
+      let {output, sql} = this._transpileSql(block.source.data)
+      let interp = this._interpolateSql(sql, inputs)
+
+      // Split SQL into statements and run each
+      let statements = interp.sql.split(';')
+      for (let statement of statements.slice(0, -1)) {
+        this._db.prepare(statement).run()
+      }
+      let rows = this._db.prepare(statements[statements.length - 1]).all()
+
+      // Convert the result rows into a data table
+      block.output = {
+        name: output,
+        value: this._packTable(rows)
+      }
+
+      return block
+    }).catch((error) => {
+      return this._appendError(block, error)
+    })
+  }
+
+  _transpileSql (sql) {
+    let outputs = []
+    sql = sql.replace(/^(\s*(\w+)\s*=\s*)\b(SELECT\b.+)/mg, function (match, group1, group2, group3) {
+      outputs.push({
+        name: group2,
+        expr: group3
+      })
+      // Insert spaces so that error reporting location is correct
+      return ' '.repeat(group1.length) + group3
+    })
+    let output = null
+    if (outputs.length === 1) {
+      output = outputs[0].name
+    } else if (outputs.length > 1) {
+      let names = outputs.map(output => output.name).join(', ')
+      throw new Error(`Block must have only one output but ${outputs.length} found "${names}"`)
+    }
+    return {output, sql}
+  }
+
+  /**
+   * Do string interpolation of variables in SQL code
    *
    * @param  {String} sql SQL code with interpolation marks e.g. `SELECT * FROM data WHERE height > ${x} AND width < ${y}`
    * @return {Object}     Interpolation variable names and interpolated e.g. `{variables:['x', 'y'], sql: 'SELECT * FROM data WHERE height > 10 AND width < 32'}`
    */
-  _interpolateSql (sql, values = {}) {
+  _interpolateSql (sql, inputs = {}) {
     let variables = []
-    sql = sql.replace(/\${([^{}]*)}/g, function (match, variable) {
-      variables.push(variable)
-      return values[variable] || '0'
+    sql = sql.replace(/\${([^{}]*)}/g, function (match, name) {
+      variables.push(name)
+      return inputs[name] || '0'
     })
     return {variables, sql}
   }
@@ -249,10 +245,25 @@ class SqliteContext extends Context {
   }
 
   /**
-   * Upack an input `{name, value}` object
+   * Unpack an array of exprression or block inputs
+   *
+   * @param  {Object} inputs Array of input objects
+   * @return {Object}        Array on unpacked inputs
+   */
+  _unpackInputs (inputs) {
+    let unpacked = {}
+    for (let input of inputs) {
+      let {name, value} = this._unpackInput(input)
+      unpacked[name] = value
+    }
+    return unpacked
+  }
+
+  /**
+   * Unpack an input `{name, value}` object
    *
    * @param  {Object} input Input object
-   * @return {Object}       Object with namne and unpacked value `{name, value}`
+   * @return {Object}       Object with name and unpacked value `{name, value}`
    */
   _unpackInput (input) {
     let {name, value} = input
@@ -303,18 +314,19 @@ class SqliteContext extends Context {
 
   // Handle an error when compiling or executing a node
   // including dealing with error locations
-  _handleError (error, node) {
+  _appendError (node, error) {
     let message = {
       type: 'error',
-      message: error.message
+      message: error.message,
+      stack: error.stack
     }
     if (error.location) {
       message.line = error.location.start.line - 1
       message.column = error.location.start.column - 1
     }
-    return Object.assign(node, {
-      messages: [message]
-    })
+    if (!node.messages) node.messages = []
+    node.messages.push(message)
+    return node
   }
 }
 

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const sqlite3 = require('sqlite3').verbose()
 const sqliteParser = require('sqlite-parser')
+const util = require('util')
 
 const Context = require('./Context')
 
@@ -15,8 +16,13 @@ class SqliteContext extends Context {
   /**
    * Compile an `expr` node
    *
-   * Check that the node consists of a single `SELECT` statement. That is, multiple `SELECT` statements,
+   * Checks that the node consists of a single `SELECT` statement. That is, multiple `SELECT` statements,
    * or other types of SQL statements, e.g `UPDATE`, `DELETE`, are invalid.
+   *
+   * Parses SQL to determine the `inputs` property of the node including variable interpolations and tables
+   * e.g. `SELECT * FROM data WHERE height > ${min_height}` creates the inputs `["min_height", "data"]`.
+   * Note that if a table already exists in the database then it is not included in `inputs` since it does
+   * not need to be provided by the execution engine
    *
    * @override
    */
@@ -52,21 +58,25 @@ class SqliteContext extends Context {
       assert(ast.statement.length === 1, 'Expression must be a single "SELECT" statement')
       assert(ast.statement[0].variant === 'select', `Expression must be a "SELECT" statement, "${ast.statement[0].variant.toUpperCase()}" not allowed`)
 
-      // Get table inputs by filtering the AST
-      const search = (object) => {
-        if (object.type === 'identifier' && object.variant === 'table') {
-          inputs.push(object.name)
-        } else if (typeof object === 'object') {
-          for (const property of Object.values(object)) {
-            search(property)
+      // Get table inputs by filtering the AST but exclude those tables that already exist in the database
+      return util.promisify(this._db.all).call(this._db, 'SELECT name FROM sqlite_master WHERE type=="table"').then(rows => {
+        const existing = rows.map(row => row.name)
+
+        const search = (object) => {
+          if (object.type === 'identifier' && object.variant === 'table') {
+            if (existing.indexOf(object.name) < 0) inputs.push(object.name)
+          } else if (typeof object === 'object') {
+            for (const property of Object.values(object)) {
+              search(property)
+            }
           }
         }
-      }
-      search(ast.statement[0])
+        search(ast.statement[0])
 
-      return Object.assign(node, {
-        messages,
-        inputs
+        return Object.assign(node, {
+          messages,
+          inputs
+        })
       })
     }).catch((error) => {
       let line

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
-const sqlite3 = require('sqlite3').verbose()
+const Database = require('better-sqlite3')
 const sqliteParser = require('sqlite-parser')
-const util = require('util')
+const uuid = require('uuid')
 
 const Context = require('./Context')
 
@@ -9,8 +9,8 @@ class SqliteContext extends Context {
   constructor () {
     super()
 
-    let db = ':memory:'
-    this._db = new sqlite3.Database(db)
+    const path = uuid()
+    this._db = new Database(path, {memory: true})
   }
 
   /**
@@ -44,6 +44,7 @@ class SqliteContext extends Context {
 
       let sql = node.source.data
       let inputs = []
+      let output = null
       let messages = []
 
       // Get interpolation inputs and interpolated SQL
@@ -56,14 +57,15 @@ class SqliteContext extends Context {
       assert(ast.statement[0].variant === 'select', `Expression must be a "SELECT" statement, "${ast.statement[0].variant.toUpperCase()}" not allowed`)
 
       // Get table inputs
-      return this._tableInputs(ast).then(tables => {
-        inputs = inputs.concat(tables)
-        inputs.sort()
+      const tables = this._tableInputs(ast)
+      inputs = inputs.concat(tables).sort().map(name => {
+        return {name}
+      })
 
-        return Object.assign(node, {
-          messages,
-          inputs
-        })
+      return Object.assign(node, {
+        inputs,
+        output,
+        messages
       })
     }).catch((error) => {
       return this._handleError(error, node)
@@ -114,7 +116,7 @@ class SqliteContext extends Context {
         return ' '.repeat(group1.length) + group3
       })
       if (outputs.length === 1) {
-        output = outputs[0].name
+        output = {name: outputs[0].name}
       } else if (outputs.length > 1) {
         let names = outputs.map(output => output.name).join(', ')
         throw new Error(`Block must have only one output but ${outputs.length} found "${names}"`)
@@ -147,16 +149,48 @@ class SqliteContext extends Context {
       }
 
       // Get table inputs
-      return this._tableInputs(ast).then(tables => {
-        inputs = inputs.concat(tables)
-        inputs.sort()
-
-        return Object.assign(node, {
-          messages,
-          output,
-          inputs
-        })
+      const tables = this._tableInputs(ast)
+      inputs = inputs.concat(tables).sort().map(name => {
+        return {name}
       })
+
+      return Object.assign(node, {
+        inputs,
+        output,
+        messages
+      })
+    }).catch((error) => {
+      return this._handleError(error, node)
+    })
+  }
+
+  /**
+   * Execute an `expr` node
+   *
+   * @override
+   */
+  executeExpr (node) {
+    return Promise.resolve().then(() => {
+      // If necessary compile the node
+      if (typeof node === 'string' || node instanceof String || !node.inputs) {
+        return this.compileExpr(node).then((compiled) => {
+          return this.executeExpr(compiled)
+        })
+      }
+      // Unpack inputs
+      let inputs = {}
+      for (let input of node.inputs) {
+        let {name, value} = this._unpackInput(input)
+        inputs[name] = value
+      }
+      // Do variable interpolation
+      let sql = node.source.data
+      let interp = this._interpolateSql(sql, inputs)
+      // Execute SQL
+      const rows = this._db.prepare(interp.sql).all()
+      // Create a data frame from the rows
+      node.output = {value: this._packTable(rows)}
+      return node
     }).catch((error) => {
       return this._handleError(error, node)
     })
@@ -196,23 +230,75 @@ class SqliteContext extends Context {
    * @return {Array}      A list of tables that are inputs into the SQL statement/s
    */
   _tableInputs (ast) {
-    return util.promisify(this._db.all).call(this._db, 'SELECT name FROM sqlite_master WHERE type=="table"').then(rows => {
-      const existing = rows.map(row => row.name)
+    let rows = this._db.prepare('SELECT name FROM sqlite_master WHERE type=="table"').all()
+    const existing = rows.map(row => row.name)
 
-      const tables = []
-      const search = (object) => {
-        if (object.type === 'identifier' && object.variant === 'table') {
-          if (existing.indexOf(object.name) < 0) tables.push(object.name)
-        } else if (typeof object === 'object') {
-          for (const property of Object.values(object)) {
-            search(property)
-          }
+    const tables = []
+    const search = (object) => {
+      if (object.type === 'identifier' && object.variant === 'table') {
+        if (existing.indexOf(object.name) < 0) tables.push(object.name)
+      } else if (typeof object === 'object') {
+        for (const property of Object.values(object)) {
+          search(property)
         }
       }
-      search(ast.statement[0])
+    }
+    search(ast.statement[0])
 
-      return tables
-    })
+    return tables
+  }
+
+  /**
+   * Upack an input `{name, value}` object
+   *
+   * @param  {Object} input Input object
+   * @return {Object}       Object with namne and unpacked value `{name, value}`
+   */
+  _unpackInput (input) {
+    let {name, value} = input
+    if (value.type === 'table') {
+      // Create a temporary SQL table for input tables
+      let cols = Object.keys(value.data)
+      let rows = value.data[cols[0]].length
+      this._db.exec(`DROP TABLE IF EXISTS ${name}`)
+      this._db.exec(`CREATE TEMPORARY TABLE ${name} (${cols.join(', ')})`)
+      let statement = this._db.prepare(`INSERT INTO ${name} VALUES (${Array(cols.length).fill('?').join(',')})`)
+      for (let row = 0; row < rows; row++) {
+        let rowData = []
+        for (let col of cols) rowData.push(value.data[col][row])
+        statement.run(rowData)
+      }
+      return {name, value: ''}
+    } else {
+      return {name, value: this.unpack(value)}
+    }
+  }
+
+  /**
+   * Pack a database table into a data table node
+   *
+   * @param  {Array} rows  Array of objects resulting from a database query
+   * @return {Object}      A data table (either a data package, or a data pointer)
+   */
+  _packTable (rows) {
+    let data = {}
+    if (rows.length > 0) {
+      let fields = Object.keys(rows[0])
+
+      for (let field of fields) {
+        data[field] = []
+      }
+      for (let row of rows) {
+        for (let field of fields) {
+          data[field].push(row[field])
+        }
+      }
+    }
+
+    return {
+      type: 'table',
+      data: data
+    }
   }
 
   // Handle an error when compiling or executing a node

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -150,21 +150,27 @@ class SqliteContext extends Context {
     return Promise.resolve().then(() => {
       // Unpack inputs and do transilation and interpolation
       let inputs = this._unpackInputs(block.inputs)
-      let {output, sql} = this._transpileSql(block.source.data)
-      let interp = this._interpolateSql(sql, inputs)
+      let trans = this._transpileSql(block.source.data)
+      let interp = this._interpolateSql(trans.sql, inputs)
 
       // Split SQL into statements and run each
-      let statements = interp.sql.split(';')
+      let statements = interp.sql.trim().split(';').filter(stmt => stmt.length > 0)
       for (let statement of statements.slice(0, -1)) {
-        this._db.prepare(statement).run()
+        let prepared = this._db.prepare(statement)
+        // Ignore all select statements except for the last one
+        if (prepared.returnsData) {
+          block.messages.push({
+            type: 'warning',
+            message: 'Ignored a SELECT statement that is before the last statement'
+          })
+        } else {
+          prepared.run()
+        }
       }
       let rows = this._db.prepare(statements[statements.length - 1]).all()
 
       // Convert the result rows into a data table
-      block.output = {
-        name: output,
-        value: this._packTable(rows)
-      }
+      block.output.value = this._packTable(rows)
 
       return block
     }).catch((error) => {
@@ -172,6 +178,10 @@ class SqliteContext extends Context {
     })
   }
 
+  /**
+   * Transpile SQL removing any `output = SELECT ...` extensions and
+   * returning the output names
+   */
   _transpileSql (sql) {
     let outputs = []
     sql = sql.replace(/^(\s*(\w+)\s*=\s*)\b(SELECT\b.+)/mg, function (match, group1, group2, group3) {
@@ -305,15 +315,16 @@ class SqliteContext extends Context {
         }
       }
     }
-
     return {
       type: 'table',
       data: data
     }
   }
 
-  // Handle an error when compiling or executing a node
-  // including dealing with error locations
+  /**
+   * Handle an error when compiling or executing a node
+   * including dealing with error locations
+   */
   _appendError (node, error) {
     let message = {
       type: 'error',

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -46,32 +46,18 @@ class SqliteContext extends Context {
       let inputs = []
       let messages = []
 
-      // Get all variable interpolation inputs and replace them prior to parsing e.g. `${x}` by `0`
-      sql = sql.replace(/\${([^{}]*)}/g, function (match, group1) {
-        inputs.push(group1)
-        return '0'
-      })
+      // Get interpolation inputs and interpolated SQL
+      let interp = this._interpolateSql(sql)
+      inputs = inputs.concat(interp.variables)
 
       // Check that the expression is a single, SELECT statement
-      const ast = sqliteParser(sql)
-      assert(ast, 'Expression could not be parsed')
+      const ast = this._parseSql(interp.sql)
       assert(ast.statement.length === 1, 'Expression must be a single "SELECT" statement')
       assert(ast.statement[0].variant === 'select', `Expression must be a "SELECT" statement, "${ast.statement[0].variant.toUpperCase()}" not allowed`)
 
-      // Get table inputs by filtering the AST but exclude those tables that already exist in the database
-      return util.promisify(this._db.all).call(this._db, 'SELECT name FROM sqlite_master WHERE type=="table"').then(rows => {
-        const existing = rows.map(row => row.name)
-
-        const search = (object) => {
-          if (object.type === 'identifier' && object.variant === 'table') {
-            if (existing.indexOf(object.name) < 0) inputs.push(object.name)
-          } else if (typeof object === 'object') {
-            for (const property of Object.values(object)) {
-              search(property)
-            }
-          }
-        }
-        search(ast.statement[0])
+      // Get table inputs
+      return this._tableInputs(ast).then(tables => {
+        inputs = inputs.concat(tables)
 
         return Object.assign(node, {
           messages,
@@ -79,21 +65,169 @@ class SqliteContext extends Context {
         })
       })
     }).catch((error) => {
-      let line
-      let column
-      if (error.location) {
-        line = error.location.start.line - 1
-        column = error.location.start.column - 1
+      return this._handleError(error, node)
+    })
+  }
+
+  /**
+   * Compile a `block` node
+   *
+   * Parses the block of SQL code for:
+   *
+   * - an output, e.g `low_gravity_planets` in `low_gravity_planets = SELECT * FROM planets WHERE gravity <= 1`
+   * - then checks that the output's expression is valid using `compileExpr`
+   * - checks for any statements that may cause side effects e.g `DELETE` or `CREATE TABLE` statements
+   *
+   * @override
+   */
+  compileBlock (node) {
+    return Promise.resolve().then(() => {
+      if (typeof node === 'string' || node instanceof String) {
+        node = {
+          type: 'block',
+          source: {
+            type: 'text',
+            lang: 'sql',
+            data: node
+          }
+        }
+      } else {
+        assert(node.source, 'Expression must have a `source` property')
+        if (node.source.lang) assert.ok(node.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
       }
-      return Object.assign(node, {
-        messages: [{
-          type: 'error',
-          message: error.message,
-          line,
-          column
-        }],
-        inputs: []
+
+      let sql = node.source.data
+
+      let inputs = []
+      let output = null
+      let messages = []
+
+      // Determine block output, if any
+      let outputs = []
+      sql = sql.replace(/^(\s*(\w+)\s*=\s*)\b(SELECT\b.+)/g, function (match, group1, group2, group3) {
+        outputs.push({
+          name: group2,
+          expr: group3
+        })
+        // Insert spaces so that error reporting location is correct
+        return ' '.repeat(group1.length) + group3
       })
+      if (outputs.length === 1) {
+        output = outputs[0].name
+      } else if (outputs.length > 1) {
+        throw new Error(`Block must have only one output but ${outputs.length} found "${outputs.join(',')}"`)
+      }
+
+      // Get interpolation inputs and interpolated SQL
+      let interp = this._interpolateSql(sql)
+      inputs = inputs.concat(interp.variables)
+
+      // Parse the intepolated SQL
+      const ast = this._parseSql(interp.sql)
+
+      // Check the block for side effects
+      const effects = []
+      const search = (object) => {
+        if (object.type === 'statement' && (object.variant !== 'list' && object.variant !== 'select')) {
+          effects.push(object.variant.toUpperCase())
+        } else if (typeof object === 'object') {
+          for (const property of Object.values(object)) {
+            search(property)
+          }
+        }
+      }
+      search(ast)
+      if (effects.length) {
+        messages.push({
+          type: 'warning',
+          message: `Block has potential side effects caused by using "${effects.join(', ')}" statements`
+        })
+      }
+
+      // Get table inputs
+      return this._tableInputs(ast).then(tables => {
+        inputs = inputs.concat(tables)
+
+        return Object.assign(node, {
+          messages,
+          output,
+          inputs
+        })
+      })
+    }).catch((error) => {
+      return this._handleError(error, node)
+    })
+  }
+
+  /**
+   * Do string interpolation of variable in SQL code
+   *
+   * @param  {String} sql SQL code with interpolation marks e.g. `SELECT * FROM data WHERE height > ${x} AND width < ${y}`
+   * @return {Object}     Interpolation variable names and interpolated e.g. `{variables:['x', 'y'], sql: 'SELECT * FROM data WHERE height > 10 AND width < 32'}`
+   */
+  _interpolateSql (sql, values = {}) {
+    let variables = []
+    sql = sql.replace(/\${([^{}]*)}/g, function (match, variable) {
+      variables.push(variable)
+      return values[variable] || '0'
+    })
+    return {variables, sql}
+  }
+
+  /**
+   * Parse SQL
+   *
+   * @param  {String} sql SQL string
+   * @return {AST}     SQL AST
+   */
+  _parseSql (sql) {
+    let ast = sqliteParser(sql)
+    assert(ast, 'Expression could not be parsed')
+    return ast
+  }
+
+  /**
+   * Get table inputs by filtering the AST but exclude those tables that already exist in the database
+   *
+   * @param  {AST}    ast SQL AST
+   * @return {Array}      A list of tables that are inputs into the SQL statement/s
+   */
+  _tableInputs (ast) {
+    return util.promisify(this._db.all).call(this._db, 'SELECT name FROM sqlite_master WHERE type=="table"').then(rows => {
+      const existing = rows.map(row => row.name)
+
+      const tables = []
+      const search = (object) => {
+        if (object.type === 'identifier' && object.variant === 'table') {
+          if (existing.indexOf(object.name) < 0) tables.push(object.name)
+        } else if (typeof object === 'object') {
+          for (const property of Object.values(object)) {
+            search(property)
+          }
+        }
+      }
+      search(ast.statement[0])
+
+      return tables
+    })
+  }
+
+  // Handle an error when compiling or executing a node
+  // including dealing with error locations
+  _handleError (error, node) {
+    let line
+    let column
+    if (error.location) {
+      line = error.location.start.line - 1
+      column = error.location.start.column - 1
+    }
+    return Object.assign(node, {
+      messages: [{
+        type: 'error',
+        message: error.message,
+        line,
+        column
+      }]
     })
   }
 }

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -12,17 +12,31 @@ class SqliteContext extends Context {
     this._db = new sqlite3.Database(db)
   }
 
+  /**
+   * Compile an `expr` node
+   *
+   * Check that the node consists of a single `SELECT` statement. That is, multiple `SELECT` statements,
+   * or other types of SQL statements, e.g `UPDATE`, `DELETE`, are invalid.
+   *
+   * @override
+   */
   compileExpr (node) {
     return Promise.resolve().then(() => {
-      let sql
       if (typeof node === 'string' || node instanceof String) {
-        sql = node
+        node = {
+          type: 'expr',
+          source: {
+            type: 'text',
+            lang: 'sql',
+            data: node
+          }
+        }
       } else {
         assert(node.source, 'Expression must have a `source` property')
         if (node.source.lang) assert.ok(node.source.lang.match(`^sql|sqlite$`), 'Expression `source.lang` property must be either "sql" or "sqlite"')
-        sql = node.source.data
       }
 
+      let sql = node.source.data
       let inputs = []
       let messages = []
 
@@ -35,7 +49,8 @@ class SqliteContext extends Context {
       // Check that the expression is a single, SELECT statement
       const ast = sqliteParser(sql)
       assert(ast, 'Expression could not be parsed')
-      assert(ast.statement.length === 1 && ast.statement[0].variant === 'select', 'Expression must be a single SELECT statement')
+      assert(ast.statement.length === 1, 'Expression must be a single "SELECT" statement')
+      assert(ast.statement[0].variant === 'select', `Expression must be a "SELECT" statement, "${ast.statement[0].variant.toUpperCase()}" not allowed`)
 
       // Get table inputs by filtering the AST
       const search = (object) => {
@@ -49,7 +64,10 @@ class SqliteContext extends Context {
       }
       search(ast.statement[0])
 
-      return { messages, inputs }
+      return Object.assign(node, {
+        messages,
+        inputs
+      })
     }).catch((error) => {
       let line
       let column
@@ -57,14 +75,15 @@ class SqliteContext extends Context {
         line = error.location.start.line - 1
         column = error.location.start.column - 1
       }
-      return {
+      return Object.assign(node, {
         messages: [{
           type: 'error',
           message: error.message,
           line,
           column
-        }]
-      }
+        }],
+        inputs: []
+      })
     })
   }
 }

--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -105,7 +105,7 @@ class SqliteContext extends Context {
 
       // Determine block output, if any
       let outputs = []
-      sql = sql.replace(/^(\s*(\w+)\s*=\s*)\b(SELECT\b.+)/g, function (match, group1, group2, group3) {
+      sql = sql.replace(/^(\s*(\w+)\s*=\s*)\b(SELECT\b.+)/mg, function (match, group1, group2, group3) {
         outputs.push({
           name: group2,
           expr: group3
@@ -116,7 +116,8 @@ class SqliteContext extends Context {
       if (outputs.length === 1) {
         output = outputs[0].name
       } else if (outputs.length > 1) {
-        throw new Error(`Block must have only one output but ${outputs.length} found "${outputs.join(',')}"`)
+        let names = outputs.map(output => output.name).join(', ')
+        throw new Error(`Block must have only one output but ${outputs.length} found "${names}"`)
       }
 
       // Get interpolation inputs and interpolated SQL
@@ -217,19 +218,16 @@ class SqliteContext extends Context {
   // Handle an error when compiling or executing a node
   // including dealing with error locations
   _handleError (error, node) {
-    let line
-    let column
+    let message = {
+      type: 'error',
+      message: error.message
+    }
     if (error.location) {
-      line = error.location.start.line - 1
-      column = error.location.start.column - 1
+      message.line = error.location.start.line - 1
+      message.column = error.location.start.column - 1
     }
     return Object.assign(node, {
-      messages: [{
-        type: 'error',
-        message: error.message,
-        line,
-        column
-      }]
+      messages: [message]
     })
   }
 }

--- a/lib/host/Host.js
+++ b/lib/host/Host.js
@@ -11,11 +11,13 @@ const HostHttpServer = require('./HostHttpServer')
 
 const JupyterContext = require('../contexts/JupyterContext')
 const NodeContext = require('../contexts/NodeContext')
+const SqliteContext = require('../contexts/SqliteContext')
 
 // Resource types
 const TYPES = {
   'JupyterContext': JupyterContext,
-  'NodeContext': NodeContext
+  'NodeContext': NodeContext,
+  'SqliteContext': SqliteContext
 }
 // Resource types specifications map
 let TYPES_SPECS = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1317,11 +1317,26 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "better-sqlite3": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-4.1.0.tgz",
+      "integrity": "sha512-IYcH1F14DfdIzDzSg7TF+0b+GpYmf6UFgV0ZWsaaczy548/S5LFMkYeKHl8EAOQQb1mSHt0lkJA0BGHMRwGOcg==",
+      "requires": {
+        "bindings": "1.3.0",
+        "integer": "1.0.3",
+        "lzz-gyp": "0.4.2"
+      }
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bl": {
       "version": "1.2.1",
@@ -4792,6 +4807,14 @@
         }
       }
     },
+    "integer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/integer/-/integer-1.0.3.tgz",
+      "integrity": "sha512-yXyGHha2cDP6qyc9EMR9SsRVYhD7gvmXgVdLhKbyE8seHx0WVo11RRRU1p+sQearQMe1Ezfc8prWx5BnmSaVVA==",
+      "requires": {
+        "bindings": "1.3.0"
+      }
+    },
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -5528,6 +5551,11 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
+    },
+    "lzz-gyp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lzz-gyp/-/lzz-gyp-0.4.2.tgz",
+      "integrity": "sha1-SVxEA0ofUMSKYPDvnCjUJ2Olspc="
     },
     "make-dir": {
       "version": "1.2.0",
@@ -10803,411 +10831,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sqlite-parser/-/sqlite-parser-1.0.1.tgz",
       "integrity": "sha1-EQGD8mgvBKxsfYrQnEREbvl21ew="
-    },
-    "sqlite3": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
-      "integrity": "sha512-6OlcAQNGaRSBLK1CuaRbKwlMFBb9DEhzmZyQP+fltNRF6XcIMpVIfXCBEcXPe1d4v9LnhkQUYkknDbA5JReqJg==",
-      "requires": {
-        "nan": "2.9.2",
-        "node-pre-gyp": "0.9.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.5"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "requires": {
-            "minipass": "2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "minimatch": "3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "yallist": "3.0.2"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "minipass": "2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.19",
-            "sax": "1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.9.0",
-          "bundled": true,
-          "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "rc": {
-          "version": "1.2.6",
-          "bundled": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "bundled": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "tar": {
-          "version": "4.4.0",
-          "bundled": true,
-          "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.1",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true
-        }
-      }
     },
     "sshpk": {
       "version": "1.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,23 +82,6 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
@@ -164,35 +147,6 @@
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "argparse": {
@@ -1375,35 +1329,6 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
         "readable-stream": "2.3.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "bluebird": {
@@ -1562,13 +1487,6 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
-      "optional": true
-    },
     "caniuse-lite": {
       "version": "1.0.30000815",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000815.tgz",
@@ -1591,17 +1509,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
       "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
       "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
     },
     "chalk": {
       "version": "2.3.2",
@@ -1775,27 +1682,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "clone": {
       "version": "2.1.1",
@@ -3898,7 +3784,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -4590,29 +4477,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -5331,6 +5195,11 @@
       "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
       "dev": true
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5356,105 +5225,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "istanbul": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.11.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-          "dev": true,
-          "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.2.0"
-          }
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
-      }
     },
     "jmp": {
       "version": "1.0.0",
@@ -5543,6 +5313,14 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -5605,13 +5383,6 @@
       "requires": {
         "is-buffer": "1.1.6"
       }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
     },
     "lazystream": {
       "version": "1.0.0",
@@ -5726,12 +5497,6 @@
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -6487,15 +6252,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.1"
-      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -9458,24 +9214,6 @@
         "mimic-fn": "1.2.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -9894,15 +9632,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
-          }
         }
       }
     },
@@ -10003,9 +9732,9 @@
       }
     },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
         "end-of-stream": "1.4.1",
         "once": "1.4.0"
@@ -10114,6 +9843,30 @@
       "requires": {
         "find-up": "2.1.0",
         "read-pkg": "3.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
     "readdirp": {
@@ -10604,16 +10357,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
-    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -10992,16 +10735,6 @@
         "mkdirp": "0.5.1",
         "portfinder": "1.0.13",
         "uuid": "3.2.1"
-      },
-      "dependencies": {
-        "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        }
       }
     },
     "spdx-correct": {
@@ -11063,6 +10796,416 @@
           "requires": {
             "is-plain-object": "2.0.4"
           }
+        }
+      }
+    },
+    "sqlite-parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sqlite-parser/-/sqlite-parser-1.0.1.tgz",
+      "integrity": "sha1-EQGD8mgvBKxsfYrQnEREbvl21ew="
+    },
+    "sqlite3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
+      "integrity": "sha512-6OlcAQNGaRSBLK1CuaRbKwlMFBb9DEhzmZyQP+fltNRF6XcIMpVIfXCBEcXPe1d4v9LnhkQUYkknDbA5JReqJg==",
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.9.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.5"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.19",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.9.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.6",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.0",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.1",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
         }
       }
     },
@@ -11651,6 +11794,17 @@
         "mkdirp": "0.5.1",
         "pump": "1.0.3",
         "tar-stream": "1.5.5"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
       }
     },
     "tar-stream": {
@@ -11662,35 +11816,6 @@
         "end-of-stream": "1.4.1",
         "readable-stream": "2.3.5",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "term-size": {
@@ -12049,34 +12174,6 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -12563,13 +12660,6 @@
         "string-width": "1.0.2"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
-    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -12628,19 +12718,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0"
-      }
     },
     "zeromq": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "request-promise": "^4.2.2",
     "send": "^0.15.4",
     "spawnteract": "^4.0.0",
+    "sqlite-parser": "^1.0.1",
+    "sqlite3": "^4.0.0",
     "uuid": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "tape": "^4.9.0"
   },
   "dependencies": {
+    "better-sqlite3": "^4.1.0",
     "body": "^5.1.0",
     "cookie": "^0.3.1",
     "execa": "^0.10.0",
@@ -63,7 +64,6 @@
     "send": "^0.15.4",
     "spawnteract": "^4.0.0",
     "sqlite-parser": "^1.0.1",
-    "sqlite3": "^4.0.0",
     "uuid": "^3.2.1"
   }
 }

--- a/test/contexts/JupyterContext.test.js
+++ b/test/contexts/JupyterContext.test.js
@@ -11,8 +11,8 @@ testPromise('JupyterContext.setup', assert => {
       assert.test('JupyterContext', t => {
         let context = new JupyterContext({
           language: 'python',
-          debug: true,
-          timeout: 10
+          // debug: true,
+          timeout: 5
         })
 
         assert.pass('JupyterContext.kernel: ' + context.kernel)

--- a/test/contexts/SqliteContext.test.js
+++ b/test/contexts/SqliteContext.test.js
@@ -72,7 +72,7 @@ test('SqliteContext.compileExpr', async assert => {
 
   compiled = await context.compileExpr('SELECT * FROM data WHERE height > ${x} AND width < ${y}') // eslint-disable-line no-template-curly-in-string
   assert.deepEqual(compiled.messages, [])
-  assert.deepEqual(compiled.inputs, ['x', 'y', 'data'])
+  assert.deepEqual(compiled.inputs, ['data', 'x', 'y'])
 
   // Tests of parsing expression for table inputs
 
@@ -104,7 +104,6 @@ test('SqliteContext.compileBlock', async assert => {
   const context = new SqliteContext()
   let block
   let compiled
-  let error
 
   // Test it be called with a `block` node or a string of SQL
   // and returns a compiled `block` node
@@ -142,6 +141,13 @@ test('SqliteContext.compileBlock', async assert => {
     type: 'warning',
     message: 'Block has potential side effects caused by using "CREATE, DROP" statements'
   }])
+
+  // Test that it returns inputs properly
+  context._db.run('CREATE TABLE existing1 (col1 TEXT)')
+
+  compiled = await context.compileExpr('SELECT * FROM input1 RIGHT JOIN existing1 WHERE existing1.col1 < ${input2}') // eslint-disable-line no-template-curly-in-string
+  assert.deepEqual(compiled.messages, [])
+  assert.deepEqual(compiled.inputs, ['input1', 'input2'])
 
   assert.end()
 })

--- a/test/contexts/SqliteContext.test.js
+++ b/test/contexts/SqliteContext.test.js
@@ -1,0 +1,67 @@
+const test = require('tape')
+
+const SqliteContext = require('../../lib/contexts/SqliteContext')
+
+test('SqliteContext.compileExpr', async assert => {
+  const context = new SqliteContext()
+  let result
+  let error
+
+  // Tests of malformed `expr` node
+
+  result = await context.compileExpr({foo: null})
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Expression must have a `source` property')
+
+  result = await context.compileExpr({source: {lang: 'python'}})
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Expression `source.lang` property must be either "sql" or "sqlite"')
+
+  // Tests of SQL syntax errors and non-expressions
+
+  result = await context.compileExpr('')
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Expression could not be parsed')
+
+  result = await context.compileExpr('An intentional syntax error')
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Syntax error found near WITH Clause (Statement)')
+  assert.deepEqual(error.line, 0)
+  assert.deepEqual(error.column, 0)
+
+  result = await context.compileExpr('SELECT * FROM mytable WHERE')
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Syntax error found near Column Identifier (WHERE Clause)')
+  assert.deepEqual(error.line, 0)
+  assert.deepEqual(error.column, 27)
+
+  result = await context.compileExpr('SELECT 42; SELECT 24;')
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Expression must be a single SELECT statement')
+
+  result = await context.compileExpr('DROP TABLE mypreciousdata')
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Expression must be a single SELECT statement')
+
+  result = await context.compileExpr('DELETE FROM mypreciousdata')
+  error = result.messages[0]
+  assert.deepEqual(error.message, 'Expression must be a single SELECT statement')
+
+  // Tests of parsing expression for string interpolation inputs
+
+  result = await context.compileExpr('SELECT * FROM data WHERE height > ${x} AND width < ${y}') // eslint-disable-line no-template-curly-in-string
+  assert.equal(result.messages.length, 0)
+  assert.deepEqual(result.inputs, ['x', 'y', 'data'])
+
+  // Tests of parsing expression for table inputs
+
+  result = await context.compileExpr('SELECT * FROM table1')
+  assert.equal(result.messages.length, 0)
+  assert.deepEqual(result.inputs, ['table1'])
+
+  result = await context.compileExpr('SELECT * FROM table1 LEFT JOIN table2')
+  assert.equal(result.messages.length, 0)
+  assert.deepEqual(result.inputs, ['table1', 'table2'])
+
+  assert.end()
+})

--- a/test/contexts/SqliteContext.test.js
+++ b/test/contexts/SqliteContext.test.js
@@ -4,64 +4,85 @@ const SqliteContext = require('../../lib/contexts/SqliteContext')
 
 test('SqliteContext.compileExpr', async assert => {
   const context = new SqliteContext()
-  let result
+  let expr
+  let compiled
   let error
+
+  // Test it be called with a `expr` node or a string of SQL
+  // and returns a compiled `expr` node
+
+  expr = {
+    type: 'expr',
+    source: {
+      type: 'text',
+      lang: 'sql',
+      data: 'SELECT * FROM data'
+    }
+  }
+  compiled = await context.compileExpr(expr)
+  assert.deepEqual(compiled.type, expr.type)
+  assert.deepEqual(compiled.source, expr.source)
+  assert.deepEqual(compiled.messages, [])
+  assert.deepEqual(compiled.inputs, ['data'])
+
+  let compiledFromString = await context.compileExpr('SELECT * FROM data')
+  assert.deepEqual(compiled, compiledFromString)
 
   // Tests of malformed `expr` node
 
-  result = await context.compileExpr({foo: null})
-  error = result.messages[0]
+  compiled = await context.compileExpr({foo: null})
+  error = compiled.messages[0]
   assert.deepEqual(error.message, 'Expression must have a `source` property')
 
-  result = await context.compileExpr({source: {lang: 'python'}})
-  error = result.messages[0]
+  compiled = await context.compileExpr({source: {lang: 'python'}})
+  error = compiled.messages[0]
   assert.deepEqual(error.message, 'Expression `source.lang` property must be either "sql" or "sqlite"')
 
   // Tests of SQL syntax errors and non-expressions
 
-  result = await context.compileExpr('')
-  error = result.messages[0]
+  compiled = await context.compileExpr('')
+  error = compiled.messages[0]
   assert.deepEqual(error.message, 'Expression could not be parsed')
 
-  result = await context.compileExpr('An intentional syntax error')
-  error = result.messages[0]
+  compiled = await context.compileExpr('An intentional syntax error')
+  error = compiled.messages[0]
   assert.deepEqual(error.message, 'Syntax error found near WITH Clause (Statement)')
   assert.deepEqual(error.line, 0)
   assert.deepEqual(error.column, 0)
 
-  result = await context.compileExpr('SELECT * FROM mytable WHERE')
-  error = result.messages[0]
+  compiled = await context.compileExpr('SELECT * FROM mytable WHERE')
+  error = compiled.messages[0]
   assert.deepEqual(error.message, 'Syntax error found near Column Identifier (WHERE Clause)')
   assert.deepEqual(error.line, 0)
   assert.deepEqual(error.column, 27)
 
-  result = await context.compileExpr('SELECT 42; SELECT 24;')
-  error = result.messages[0]
-  assert.deepEqual(error.message, 'Expression must be a single SELECT statement')
+  compiled = await context.compileExpr('SELECT 42; SELECT 24;')
+  error = compiled.messages[0]
+  assert.deepEqual(error.message, 'Expression must be a single "SELECT" statement')
 
-  result = await context.compileExpr('DROP TABLE mypreciousdata')
-  error = result.messages[0]
-  assert.deepEqual(error.message, 'Expression must be a single SELECT statement')
+  compiled = await context.compileExpr('DROP TABLE mypreciousdata')
+  error = compiled.messages[0]
+  assert.deepEqual(error.message, 'Expression must be a "SELECT" statement, "DROP" not allowed')
 
-  result = await context.compileExpr('DELETE FROM mypreciousdata')
-  error = result.messages[0]
-  assert.deepEqual(error.message, 'Expression must be a single SELECT statement')
+  compiled = await context.compileExpr('DELETE FROM mypreciousdata')
+  error = compiled.messages[0]
+  assert.deepEqual(error.message, 'Expression must be a "SELECT" statement, "DELETE" not allowed')
 
   // Tests of parsing expression for string interpolation inputs
 
-  result = await context.compileExpr('SELECT * FROM data WHERE height > ${x} AND width < ${y}') // eslint-disable-line no-template-curly-in-string
-  assert.equal(result.messages.length, 0)
-  assert.deepEqual(result.inputs, ['x', 'y', 'data'])
+  compiled = await context.compileExpr('SELECT * FROM data WHERE height > ${x} AND width < ${y}') // eslint-disable-line no-template-curly-in-string
+  assert.equal(compiled.messages.length, 0)
+  assert.deepEqual(compiled.inputs, ['x', 'y', 'data'])
 
   // Tests of parsing expression for table inputs
 
-  result = await context.compileExpr('SELECT * FROM table1')
-  assert.equal(result.messages.length, 0)
-  assert.deepEqual(result.inputs, ['table1'])
+  compiled = await context.compileExpr('SELECT * FROM table1')
+  assert.equal(compiled.messages.length, 0)
+  assert.deepEqual(compiled.inputs, ['table1'])
 
-  result = await context.compileExpr('SELECT * FROM table1 LEFT JOIN table2')
-  assert.equal(result.messages.length, 0)
-  assert.deepEqual(result.inputs, ['table1', 'table2'])
+  compiled = await context.compileExpr('SELECT * FROM table1 LEFT JOIN table2')
+  assert.equal(compiled.messages.length, 0)
+  assert.deepEqual(compiled.inputs, ['table1', 'table2'])
 
   assert.end()
 })

--- a/test/contexts/SqliteContext.test.js
+++ b/test/contexts/SqliteContext.test.js
@@ -135,6 +135,13 @@ test('SqliteContext.compileBlock', async assert => {
     column: 0
   }])
 
+  // Test that it errors if more than one output
+  compiled = await context.compileBlock('out1 = SELECT 42;\nout2 = SELECT 42')
+  assert.deepEqual(compiled.messages, [{
+    type: 'error',
+    message: 'Block must have only one output but 2 found "out1, out2"'
+  }])
+
   // Test that it warns of potential side-effects
   compiled = await context.compileBlock('CREATE TABLE foo (bar INT); DROP TABLE foo')
   assert.deepEqual(compiled.messages, [{

--- a/test/contexts/SqliteContext.test.js
+++ b/test/contexts/SqliteContext.test.js
@@ -300,6 +300,26 @@ test('SqliteContext.executeBlock', async assert => {
   assert.end()
 })
 
+test('SqliteContext.list', async assert => {
+  const context = new SqliteContext()
+
+  context._db.exec(SMALL_TABLE_SQL)
+
+  let list = await context.list()
+  assert.deepEqual(list, [])
+
+  await context.executeBlock(await context.compileBlock('a = SELECT 1'))
+  assert.deepEqual(await context.list(), ['a'])
+
+  await context.executeBlock(await context.compileBlock('SELECT 2'))
+  assert.deepEqual(await context.list(), ['a'])
+
+  await context.executeBlock(await context.compileBlock('b = SELECT 3'))
+  assert.deepEqual(await context.list(), ['a', 'b'])
+
+  assert.end()
+})
+
 // Some SQL to create test tables
 const SMALL_TABLE_SQL = `
   CREATE TABLE test_table_small (col1 TEXT, col2 INT);


### PR DESCRIPTION
Provides a `SqliteContext` class for this package. Currently, `SqliteContext` classes are implemented in the `stencila/r` and `stencila/py` (partial). This ports those implementations to Node.js (with some refinements to the API along the way). 

The advantages of having a `SqliteContext` here are:

- Javascript developers can more easily test out integration with the front end user interfaces by running `npm start`
- by using this package in `stencila/desktop` we can provide users with the ability to execute SQL without any other packages or Docker images.