### PR TITLE
JavascriptContext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - 8
 
+cache:
+  directories:
+    - node_modules
+
 addons:
   apt:
     sources:
@@ -18,18 +22,14 @@ before_install:
   # Install ipykernel for testing of JupyterContext
   - pip install ipykernel --user
 
-cache:
-  directories:
-    - node_modules
-
 script:
   # Check that ipykernel will run
   - python -m ipykernel_launcher &
 
-  - make lint
-  - make check
-  - make cover
-  - make docs
+  - npm run lint
+  - npm run check
+  - npm run cover
+  - npm run docs
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ cover:
 
 docs:
 	npm run docs
+.PHONY: docs
 
 clean:
-	rm -rf node_modules
+	npm run clean

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Install
 
-```sh
+```bash
 npm install stencila-node -g
 ```
 
@@ -24,7 +24,7 @@ This creates a host manifest file in the Stencila hosts directory (e.g. `~/.sten
 
 This package lets you run JavaScript and other code from inside Stencila documents. First, you need to start serving the Stencila Host within this package. You can do that at a terminal,
 
-```sh
+```bash
 stencila-node
 ```
 
@@ -36,6 +36,14 @@ stencila.run()
 ```
 
 This will serve a Stencila `Host` on localhost. You can then open your Stencila document from within the [Stencila Desktop](https://github.com/stencila/desktop). The host will be automatically detected by the desktop app and you'll be able to execute Javascript code cells from within your documents.
+
+You can also use this package to compile libraries of Javascript functions for use within Stencila:
+
+```bash
+stencila-node compile "~/stencila/source/libcore/"
+```
+
+This creates a minified Javascript bundle, in this example at `"~/stencila/source/libcore/libcore.min.js`
 
 API documentation is available at https://stencila.github.io/node.
 

--- a/bin/stencila-node.js
+++ b/bin/stencila-node.js
@@ -24,13 +24,13 @@ const stencila = require('../lib/index.js')
 
   // Function options as JSON object from second argument or stdin
   let inp = process.argv[3] || await getStdin()
-  let options = {}
+  let options
   if (inp && inp.length) {
     try {
       options = JSON.parse(inp)
     } catch (error) {
-      console.error('Error parsing JSON options: ' + inp)
-      process.exit(1)
+      // Treat options as a string argument
+      options = inp
     }
   }
 

--- a/lib/contexts/Context.js
+++ b/lib/contexts/Context.js
@@ -136,6 +136,7 @@ class Context {
     switch (node.type) {
       case 'get': return this.executeGet(node)
       case 'func': return this.executeFunc(node)
+      default: return this.unpack(node)
     }
   }
 }

--- a/lib/contexts/Context.js
+++ b/lib/contexts/Context.js
@@ -36,7 +36,9 @@ class Context {
   }
 
   async packPackage (value) {
-    const type = value.type || typeof value
+    let type
+    if (value === null) type = 'null'
+    else type = value.type || typeof value
     switch (type) {
       default: return {type, data: value}
     }
@@ -125,11 +127,16 @@ class Context {
   }
 
   async compile (node) {
-    return node
+    switch (node.type) {
+      case 'func': return this.compileFunc(node)
+    }
   }
 
   async execute (node) {
-    return node
+    switch (node.type) {
+      case 'get': return this.executeGet(node)
+      case 'func': return this.executeFunc(node)
+    }
   }
 }
 

--- a/lib/contexts/Context.js
+++ b/lib/contexts/Context.js
@@ -21,6 +21,10 @@ class Context {
     return this._name
   }
 
+  async libraries () {
+    return {}
+  }
+
   async pack (value) {
     return this.packPackage(value)
   }
@@ -128,16 +132,39 @@ class Context {
 
   async compile (node) {
     switch (node.type) {
+      case 'cell': return this.compileCell(node)
       case 'func': return this.compileFunc(node)
     }
+  }
+
+  async compileCell (cell) {
+    return cell
+  }
+
+  async compileFunc (func) {
+    return func
   }
 
   async execute (node) {
     switch (node.type) {
       case 'get': return this.executeGet(node)
+      case 'cell': return this.executeCell(node)
       case 'func': return this.executeFunc(node)
+      case 'call': return this.executeCall(node)
       default: return this.unpack(node)
     }
+  }
+
+  async executeCell (cell) {
+    return this.pack(null)
+  }
+
+  async executeFunc (func) {
+    return this.pack(null)
+  }
+
+  async executeCall (call) {
+    return this.pack(null)
   }
 }
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -16,7 +16,9 @@ class JavascriptContext extends Context {
      *
      * @type {Object}
      */
-    this._libraries = {}
+    this._libraries = {
+      'local': {}
+    }
   }
 
   async libraries () {
@@ -35,6 +37,18 @@ class JavascriptContext extends Context {
           lang: 'js',
           data: func
         }
+      }
+      try {
+        func.body = eval(func) // eslint-disable-line no-eval
+      } catch (error) {}
+    } else if (typeof func === 'function') {
+      func = {
+        source: {
+          type: 'text',
+          lang: 'js',
+          data: func.toString()
+        },
+        body: func
       }
     }
     if (!func.type) func.type = 'func'
@@ -190,8 +204,84 @@ class JavascriptContext extends Context {
     return func
   }
 
-  async executeCall (call) {
+  async executeGet (get) {
+    const func = this._libraries['local'][get.name]
+    if (!func) throw new Error(`Could not get function "${get.name}"`)
+    return func
+  }
 
+  async executeFunc (func) {
+    func = await this.compileFunc(func)
+    this._libraries['local'][func.name] = func
+  }
+
+  async executeCall (call) {
+    // Get the function
+    const func = await this.execute(call.func)
+
+    // Using `func.params` specification, map the call's arguments onto the function's parameters
+    let args = []
+    let argsIndex = 0
+    let argsUsed = 0
+    let namedArgs
+    let namedArgsUsed = []
+    if (func.params) {
+      for (let param of func.params) {
+        if (param.repeats) {
+          // Put the remaining arguments into an array
+          let remaining = []
+          for (; argsIndex < call.args.length; argsIndex++) {
+            remaining.push(await this.execute(call.args[argsIndex]))
+            argsUsed++
+          }
+          args.push(remaining)
+          break
+        } else if (param.namedRepeats) {
+          // Put the remaining named arguments into an object
+          if (call.namedArgs) {
+            namedArgs = {}
+            for (let name of Object.keys(call.namedArgs)) {
+              if (namedArgsUsed.indexOf(name) < 0) {
+                namedArgs[name] = await this.execute(call.namedArgs[name])
+                namedArgsUsed.push(param.name)
+              }
+            }
+          }
+          break
+        } else {
+          // Get the argument for the parameter either by name or by index
+          let arg
+          if (call.namedArgs) {
+            arg = call.namedArgs[param.name]
+            if (arg) namedArgsUsed.push(param.name)
+          }
+          if (!arg && call.args) {
+            arg = call.args[argsIndex]
+            if (arg) argsUsed++
+          }
+          if (!arg && !param.default) {
+            throw new Error(`Function parameter "${param.name}" must be supplied`)
+          }
+          if (arg) args.push(await this.execute(arg))
+          else args.push(undefined)
+        }
+        argsIndex++
+      }
+    }
+    // Check that there are no extra, unused arguments in call
+    if (call.args && argsUsed < call.args.length) {
+      const extra = call.args.length - argsUsed
+      throw new Error(`Function was supplied ${extra} extra arguments`)
+    }
+    if (call.namedArgs && namedArgsUsed.length < Object.keys(call.namedArgs).length) {
+      const extra = Object.keys(call.namedArgs).filter((arg) => namedArgsUsed.indexOf(arg) < 0)
+        .map((arg) => `"${arg}"`)
+        .join(', ')
+      throw new Error(`Function was supplied extra named arguments ${extra}`)
+    }
+    // Return the actual function call
+    let result = namedArgs ? func.body(...args, namedArgs) : func.body(...args)
+    return this.pack(result)
   }
 }
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -8,13 +8,18 @@ const Context = require('./Context')
  * A Node.js context for executing  code
  */
 class JavascriptContext extends Context {
-  compile (node) {
-    if (node.type === 'func') {
-      return this.compileFunc(node)
-    }
+  constructor (host, name) {
+    super(host, name)
+
+    /**
+     * Libraries registered in this context
+     *
+     * @type {Object}
+     */
+    this._libraries = {}
   }
 
-  compileFunc (func) {
+  async compileFunc (func) {
     if (typeof func === 'string' || func instanceof String) {
       func = {
         source: {

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -16,17 +16,11 @@ class JavascriptContext extends Context {
      *
      * @type {Object}
      */
-    this._libraries = {
-      'local': {}
-    }
+    this._libraries = {}
   }
 
   async libraries () {
-    let libs = {}
-    for (let [name, lib] of Object.entries(this._libraries)) {
-      libs[name] = lib.LIBRARY
-    }
-    return libs
+    return this._libraries
   }
 
   async compileFunc (func) {
@@ -205,13 +199,26 @@ class JavascriptContext extends Context {
   }
 
   async executeGet (get) {
-    const func = this._libraries['local'][get.name]
-    if (!func) throw new Error(`Could not get function "${get.name}"`)
-    return func
+    let from
+    if (get.from) from = await this.executeGet(get.from)
+    else from = this._libraries
+    let value = from[get.name]
+    if (!value) throw new Error(`Could not get value "${get.name}"`)
+    return value
+  }
+
+  async executeCell (cell) {
+    const code = cell.source.data
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+    const func = new AsyncFunction('_', 'return ' + code) // eslint-disable-line no-new-func
+    const value = await func(this)
+    cell.output.value = this.pack(value)
+    return cell
   }
 
   async executeFunc (func) {
     func = await this.compileFunc(func)
+    if (!this._libraries['local']) this._libraries['local'] = {}
     this._libraries['local'][func.name] = func
   }
 
@@ -279,9 +286,13 @@ class JavascriptContext extends Context {
         .join(', ')
       throw new Error(`Function was supplied extra named arguments ${extra}`)
     }
-    // Return the actual function call
+    // Execute the actual function call
     let result = namedArgs ? func.body(...args, namedArgs) : func.body(...args)
-    return this.pack(result)
+
+    return {
+      result: await this.pack(result),
+      messages: []
+    }
   }
 }
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -236,7 +236,7 @@ class JavascriptContext extends Context {
           }
           args.push(remaining)
           break
-        } else if (param.namedRepeats) {
+        } else if (param.extends) {
           // Put the remaining named arguments into an object
           if (call.namedArgs) {
             namedArgs = {}

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -1,0 +1,145 @@
+const acorn = require('acorn')
+const doctrine = require('doctrine')
+const walk = require('acorn/dist/walk')
+
+const Context = require('./Context')
+
+/**
+ * A Node.js context for executing  code
+ */
+class JavascriptContext extends Context {
+  compile (node) {
+    if (node.type === 'func') {
+      return this.compileFunc(node)
+    }
+  }
+
+  compileFunc (func) {
+    if (typeof func === 'string' || func instanceof String) {
+      func = {
+        source: {
+          type: 'text',
+          lang: 'js',
+          data: func
+        }
+      }
+    }
+    if (!func.type) func.type = 'func'
+
+    let code = func.source.data
+
+    // Parse the source code collecting any comments
+    let ast
+    let docs
+    try {
+      ast = acorn.parse(code, {
+        onComment: (block, text) => {
+          if (block && !docs) docs = text
+        }
+      })
+    } catch (error) {
+      throw new Error('Syntax error in source code: ' + error.message)
+    }
+
+    // Extract the first `FunctionDeclaration` from the AST.
+    let decl
+    walk.simple(ast, {
+      FunctionDeclaration (node) {
+        if (!decl) decl = node
+      }
+    })
+    if (!decl) throw new Error('No function definition found in the source code')
+
+    // Get function name
+    const name = decl.id.name
+
+    // Process each parameter declaration node into a parameter spec
+    let params = []
+    for (let node of decl.params) {
+      let param = {}
+      switch (node.type) {
+        case 'Identifier':
+          if (node.name.substring(0, 3) === '___') {
+            param.name = node.name.substring(3)
+            param.extends = true
+          } else {
+            param.name = node.name
+          }
+          break
+        case 'RestElement':
+          param.name = node.argument.name
+          param.repeats = true
+          break
+        case 'AssignmentPattern':
+          param.name = node.left.name
+          param.default = code.substring(node.right.start, node.right.end)
+          break
+        default:
+          throw new Error(`Unhandled parameter node type "${node.type}"`)
+      }
+      params.push(param)
+    }
+
+    if (docs) {
+      // Strip spaces and asterisks from front of each line
+      docs = docs.replace(/^\s*\*?/mg, '')
+      // Parse JSDoc documentation
+      const tags = doctrine.parse(docs, {
+        sloppy: true // allow optional parameters to be specified in brackets
+      }).tags
+      // Process tags
+      for (let tag of tags) {
+        switch (tag.title) {
+          case 'param':
+            // Get the parameter
+            let which = null
+            for (let [index, param] of Object.entries(params)) {
+              if (param.name === tag.name) {
+                which = index
+                break
+              }
+            }
+            if (which === null) throw new Error(`Documentation comment @param for "${tag.name}" not in function definition`)
+            let param = params[which]
+
+            if (tag.type) {
+              let type
+              switch (tag.type.type) {
+                case 'AllLiteral':
+                  type = 'any'
+                  break
+                case 'NameExpression':
+                  type = tag.type.name
+                  break
+                case 'TypeApplication':
+                  type = tag.type.expression.name + '[' +
+                         tag.type.applications.map((application) => application.name).join(',') + ']'
+                  break
+                case 'OptionalType':
+                  type = tag.type.expression.name
+                  type = tag.default ? type : 'null'
+                  break
+                default:
+                  throw new Error('Unhandled @param type specification: ' + tag.type.type)
+              }
+              param.type = type
+            }
+
+            if (tag.description) param.description = tag.description
+        }
+      }
+    }
+
+    func.name = name
+    func.params = params
+
+    return func
+  }
+}
+
+JavascriptContext.spec = {
+  name: 'JavascriptContext',
+  client: 'ContextHttpClient'
+}
+
+module.exports = JavascriptContext

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -8,7 +8,6 @@ const Context = require('./Context')
  * A Node.js context for executing  code
  */
 class JavascriptContext extends Context {
-
   compile (node) {
     if (node.type === 'func') {
       return this.compileFunc(node)
@@ -107,7 +106,9 @@ class JavascriptContext extends Context {
             break
 
           case 'example':
-            examples.push(tag.description)
+            let example = {usage: tag.description}
+            if (tag.caption) example.caption = tag.caption
+            examples.push(example)
             break
 
           case 'param':

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -80,7 +80,7 @@ class JavascriptContext extends Context {
       params.push(param)
     }
 
-    let return_
+    let examples = []
     if (docs) {
       // Strip spaces and asterisks from front of each line
       docs = docs.replace(/^\s*\*?/mg, '')
@@ -91,6 +91,22 @@ class JavascriptContext extends Context {
       // Process tags
       for (let tag of tags) {
         switch (tag.title) {
+          case 'name':
+            if (tag.name !== name) throw new Error(`Documentation tag @name with name "${tag.name}" differs from name in function definition`)
+            break
+
+          case 'title':
+            func.title = tag.description
+            break
+
+          case 'summary':
+            func.summary = tag.description
+            break
+
+          case 'example':
+            examples.push(tag.description)
+            break
+
           case 'param':
             // Get the parameter object extracted from the function definition
             let which = null
@@ -100,7 +116,7 @@ class JavascriptContext extends Context {
                 break
               }
             }
-            if (which === null) throw new Error(`Documentation comment @param for "${tag.name}" not in function definition`)
+            if (which === null) throw new Error(`Documentation tag @param for parameter "${tag.name}" which is not in function definition`)
             let param = params[which]
 
             if (tag.type) {
@@ -129,7 +145,7 @@ class JavascriptContext extends Context {
             break
 
           case 'return':
-            return_ = {}
+            func.return = {}
             if (tag.type) {
               let type
               switch (tag.type.type) {
@@ -139,17 +155,17 @@ class JavascriptContext extends Context {
                 default:
                   throw new Error('Unhandled @return type specification: ' + tag.type.type)
               }
-              return_.type = type
+              func.return.type = type
             }
-            if (tag.description) return_.description = tag.description
+            if (tag.description) func.return.description = tag.description
             break
         }
       }
     }
 
     func.name = name
-    func.params = params
-    if (return_) func.return = return_
+    if (params.length) func.params = params
+    if (examples.length) func.examples = examples
 
     return func
   }

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -80,6 +80,7 @@ class JavascriptContext extends Context {
       params.push(param)
     }
 
+    let return_
     if (docs) {
       // Strip spaces and asterisks from front of each line
       docs = docs.replace(/^\s*\*?/mg, '')
@@ -91,7 +92,7 @@ class JavascriptContext extends Context {
       for (let tag of tags) {
         switch (tag.title) {
           case 'param':
-            // Get the parameter
+            // Get the parameter object extracted from the function definition
             let which = null
             for (let [index, param] of Object.entries(params)) {
               if (param.name === tag.name) {
@@ -124,14 +125,31 @@ class JavascriptContext extends Context {
               }
               param.type = type
             }
-
             if (tag.description) param.description = tag.description
+            break
+
+          case 'return':
+            return_ = {}
+            if (tag.type) {
+              let type
+              switch (tag.type.type) {
+                case 'NameExpression':
+                  type = tag.type.name
+                  break
+                default:
+                  throw new Error('Unhandled @return type specification: ' + tag.type.type)
+              }
+              return_.type = type
+            }
+            if (tag.description) return_.description = tag.description
+            break
         }
       }
     }
 
     func.name = name
     func.params = params
+    if (return_) func.return = return_
 
     return func
   }

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -136,6 +136,9 @@ class JavascriptContext extends Context {
                   type = tag.type.expression.name
                   type = tag.default ? type : 'null'
                   break
+                case 'RestType':
+                  type = tag.type.expression.name
+                  break
                 default:
                   throw new Error('Unhandled @param type specification: ' + tag.type.type)
               }

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -19,6 +19,14 @@ class JavascriptContext extends Context {
     this._libraries = {}
   }
 
+  async libraries () {
+    let libs = {}
+    for (let [name, lib] of Object.entries(this._libraries)) {
+      libs[name] = lib.LIBRARY
+    }
+    return libs
+  }
+
   async compileFunc (func) {
     if (typeof func === 'string' || func instanceof String) {
       func = {
@@ -180,6 +188,10 @@ class JavascriptContext extends Context {
     if (examples.length) func.examples = examples
 
     return func
+  }
+
+  async executeCall (call) {
+
   }
 }
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -32,17 +32,13 @@ class JavascriptContext extends Context {
           data: func
         }
       }
-      try {
-        func.body = eval(func) // eslint-disable-line no-eval
-      } catch (error) {}
     } else if (typeof func === 'function') {
       func = {
         source: {
           type: 'text',
           lang: 'js',
           data: func.toString()
-        },
-        body: func
+        }
       }
     }
     if (!func.type) func.type = 'func'
@@ -198,10 +194,22 @@ class JavascriptContext extends Context {
     return func
   }
 
+  async executeFunc (func) {
+    func = await this.compileFunc(func)
+
+    let code = func.source.data
+    func._func = eval(code + ';' + func.name) // eslint-disable-line no-eval
+
+    if (!this._libraries['local']) this._libraries['local'] = {}
+    this._libraries['local'][func.name] = func
+    return func
+  }
+
   async executeGet (get) {
     let from
     if (get.from) from = await this.executeGet(get.from)
     else from = this._libraries
+    if (from.type === 'library') from = from.funcs
     let value = from[get.name]
     if (!value) throw new Error(`Could not get value "${get.name}"`)
     return value
@@ -214,12 +222,6 @@ class JavascriptContext extends Context {
     const value = await func(this)
     cell.output.value = this.pack(value)
     return cell
-  }
-
-  async executeFunc (func) {
-    func = await this.compileFunc(func)
-    if (!this._libraries['local']) this._libraries['local'] = {}
-    this._libraries['local'][func.name] = func
   }
 
   async executeCall (call) {
@@ -287,12 +289,10 @@ class JavascriptContext extends Context {
       throw new Error(`Function was supplied extra named arguments ${extra}`)
     }
     // Execute the actual function call
-    let result = namedArgs ? func.body(...args, namedArgs) : func.body(...args)
+    let value = namedArgs ? func._func(...args, namedArgs) : func._func(...args)
+    if (value !== undefined) call.value = await this.pack(value)
 
-    return {
-      result: await this.pack(result),
-      messages: []
-    }
+    return call
   }
 }
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -8,6 +8,7 @@ const Context = require('./Context')
  * A Node.js context for executing  code
  */
 class JavascriptContext extends Context {
+
   compile (node) {
     if (node.type === 'func') {
       return this.compileFunc(node)
@@ -33,6 +34,7 @@ class JavascriptContext extends Context {
     let docs
     try {
       ast = acorn.parse(code, {
+        sourceType: 'module',
         onComment: (block, text) => {
           if (block && !docs) docs = text
         }
@@ -85,9 +87,10 @@ class JavascriptContext extends Context {
       // Strip spaces and asterisks from front of each line
       docs = docs.replace(/^\s*\*?/mg, '')
       // Parse JSDoc documentation
-      const tags = doctrine.parse(docs, {
+      const {description, tags} = doctrine.parse(docs, {
         sloppy: true // allow optional parameters to be specified in brackets
-      }).tags
+      })
+      func.description = description
       // Process tags
       for (let tag of tags) {
         switch (tag.title) {

--- a/lib/contexts/NodeContext.js
+++ b/lib/contexts/NodeContext.js
@@ -1,12 +1,75 @@
+const fs = require('fs')
+let glob = require('glob')
+const path = require('path')
+const rollup = require('rollup')
+const rollupUglify = require('rollup-plugin-uglify')
+const tmp = require('tmp')
+const util = require('util')
+glob = util.promisify(glob)
+
 const JavascriptContext = require('./JavascriptContext')
 
 /**
  * A Node.js context for executing Javascript code
  */
 class NodeContext extends JavascriptContext {
-  executeBlock (block) {
-    block.output.value = this.pack('Hello from Node.js. This is just a test!')
-    return block
+  /**
+   * Compile a Javascript function from a source code file
+   *
+   * @param  {String} file File path
+   * @return {Object}      Function object
+   */
+  async compileFuncFile (file) {
+    let content = fs.readFileSync(file, 'utf8')
+    try {
+      return this.compileFunc(content)
+    } catch (error) {
+      throw new Error(`Error compiling file "${file}": ` + error.message)
+    }
+  }
+
+  /**
+   * Compile a Stencila library so that it can be loaded either into
+   * a `NodeContext` or another `JavascriptContext` (e.g one embedded
+   * into a Stencila web or desktop interface).
+   *
+   * Creates a Javascript bundle which exports both function definitions and
+   * a function specification object (exported as `FUNCS`).
+   *
+   * @param {String} folder Path to library folder
+   * @param {String} name Name of library (defaults to the folder name)
+   * @param {Boolean} minify Should the bundle be minified? (defaults to true)
+   */
+  async compileLibrary (folder, name = null, minify = true) {
+    let funcs = {}
+    let index = ''
+    let files = await glob(path.join(folder, 'funcs', '*.js'), {ignore: '**/_*'})
+    for (let file of files) {
+      let func = await this.compileFuncFile(file)
+      delete func.source
+      funcs[func.name] = func
+      index += `export { default as ${func.name} } from '${file}'\n`
+    }
+    index += `export const FUNCS = ${JSON.stringify(funcs, null, '  ')}\n`
+
+    const indexPath = tmp.tmpNameSync()
+    fs.writeFileSync(indexPath, index)
+
+    const plugins = []
+    if (minify) plugins.push(rollupUglify())
+    const bundle = await rollup.rollup({
+      input: indexPath,
+      plugins: plugins
+    })
+
+    let filename = name || path.basename(folder)
+    if (minify) filename += '.min'
+    filename += '.js'
+    await bundle.write({
+      format: 'umd',
+      name: 'local',
+      file: path.join(folder, filename)
+    })
   }
 }
 

--- a/lib/contexts/NodeContext.js
+++ b/lib/contexts/NodeContext.js
@@ -59,11 +59,12 @@ class NodeContext extends JavascriptContext {
     let index = ''
     for (let file of files) {
       let func = await this.compileFuncFile(file)
-      delete func.source
-      delete func.body
       funcs[func.name] = func
+      delete func.source
+
+      const json = JSON.stringify(func, null, '  ')
       index += `import ${func.name}_ from '${file}'\n`
-      index += `export const ${func.name} = ${JSON.stringify(func, null, '  ')}\n`
+      index += `export const ${func.name} = ${json}\n`
       index += `${func.name}.body = ${func.name}_\n\n`
     }
 
@@ -101,7 +102,7 @@ class NodeContext extends JavascriptContext {
     this._libraries[library.name] = library
     return {
       type: 'library',
-      name: name,
+      name: library.name,
       funcs: library.funcs
     }
   }

--- a/lib/contexts/NodeContext.js
+++ b/lib/contexts/NodeContext.js
@@ -34,23 +34,23 @@ class NodeContext extends JavascriptContext {
    * into a Stencila web or desktop interface).
    *
    * Creates a Javascript bundle which exports both function definitions and
-   * a library specification object (exported as `LIBRARY`).
+   * a function specification objects.
    *
    * @param {String} folder Path to library folder
    * @param {String} name Name of library (defaults to the folder name)
    * @param {Boolean} minify Should the bundle be minified? (defaults to true)
    */
   async compileLibrary (folder, name = null, minify = true) {
-    let funcs = {}
     let index = ''
     let files = await glob(path.join(folder, 'funcs', '*.js'), {ignore: '**/_*'})
     for (let file of files) {
       let func = await this.compileFuncFile(file)
       delete func.source
-      funcs[func.name] = func
-      index += `export { default as ${func.name} } from '${file}'\n`
+      delete func.body
+      index += `import ${func.name}_ from '${file}'\n`
+      index += `export const ${func.name} = ${JSON.stringify(func, null, '  ')}\n`
+      index += `${func.name}.body = ${func.name}_\n\n`
     }
-    index += `export const LIBRARY = ${JSON.stringify(funcs, null, '  ')}\n`
 
     const indexPath = tmp.tmpNameSync()
     fs.writeFileSync(indexPath, index)

--- a/lib/contexts/NodeContext.js
+++ b/lib/contexts/NodeContext.js
@@ -34,7 +34,7 @@ class NodeContext extends JavascriptContext {
    * into a Stencila web or desktop interface).
    *
    * Creates a Javascript bundle which exports both function definitions and
-   * a function specification object (exported as `FUNCS`).
+   * a library specification object (exported as `LIBRARY`).
    *
    * @param {String} folder Path to library folder
    * @param {String} name Name of library (defaults to the folder name)
@@ -50,7 +50,7 @@ class NodeContext extends JavascriptContext {
       funcs[func.name] = func
       index += `export { default as ${func.name} } from '${file}'\n`
     }
-    index += `export const FUNCS = ${JSON.stringify(funcs, null, '  ')}\n`
+    index += `export const LIBRARY = ${JSON.stringify(funcs, null, '  ')}\n`
 
     const indexPath = tmp.tmpNameSync()
     fs.writeFileSync(indexPath, index)
@@ -62,14 +62,23 @@ class NodeContext extends JavascriptContext {
       plugins: plugins
     })
 
-    let filename = name || path.basename(folder)
-    if (minify) filename += '.min'
-    filename += '.js'
+    let bundleName = name || path.basename(folder)
+    if (minify) bundleName += '.min'
+    bundleName += '.js'
+    let bundlePath = path.join(folder, bundleName)
     await bundle.write({
       format: 'umd',
       name: 'local',
-      file: path.join(folder, filename)
+      file: bundlePath
     })
+
+    return bundlePath
+  }
+
+  async executeLibrary (folder, name) {
+    const bundle = await this.compileLibrary(folder, name)
+    const lib = require(bundle)
+    this._libraries[name] = lib
   }
 }
 

--- a/lib/contexts/NodeContext.js
+++ b/lib/contexts/NodeContext.js
@@ -4,6 +4,7 @@ const path = require('path')
 const rollup = require('rollup')
 const rollupUglify = require('rollup-plugin-uglify')
 const tmp = require('tmp')
+const untildify = require('untildify')
 const util = require('util')
 glob = util.promisify(glob)
 
@@ -41,12 +42,26 @@ class NodeContext extends JavascriptContext {
    * @param {Boolean} minify Should the bundle be minified? (defaults to true)
    */
   async compileLibrary (folder, name = null, minify = true) {
+    folder = untildify(folder)
+    name = name || path.basename(folder)
+
+    try {
+      fs.statSync(folder)
+    } catch (error) {
+      throw new Error(`No such folder "${folder}"`)
+    }
+
+    const pattern = path.join(folder, 'funcs', '*.js')
+    const files = await glob(pattern, {ignore: '**/_*'})
+    if (files.length === 0) throw new Error(`No functions found matching pattern "${pattern}"`)
+
+    let funcs = {}
     let index = ''
-    let files = await glob(path.join(folder, 'funcs', '*.js'), {ignore: '**/_*'})
     for (let file of files) {
       let func = await this.compileFuncFile(file)
       delete func.source
       delete func.body
+      funcs[func.name] = func
       index += `import ${func.name}_ from '${file}'\n`
       index += `export const ${func.name} = ${JSON.stringify(func, null, '  ')}\n`
       index += `${func.name}.body = ${func.name}_\n\n`
@@ -62,7 +77,7 @@ class NodeContext extends JavascriptContext {
       plugins: plugins
     })
 
-    let bundleName = name || path.basename(folder)
+    let bundleName = name
     if (minify) bundleName += '.min'
     bundleName += '.js'
     let bundlePath = path.join(folder, bundleName)
@@ -72,13 +87,23 @@ class NodeContext extends JavascriptContext {
       file: bundlePath
     })
 
-    return bundlePath
+    return {
+      type: 'library',
+      name: name,
+      funcs: funcs,
+      bundle: bundlePath
+    }
   }
 
-  async executeLibrary (folder, name) {
-    const bundle = await this.compileLibrary(folder, name)
-    const lib = require(bundle)
-    this._libraries[name] = lib
+  async executeLibrary (folder, name = null) {
+    const library = await this.compileLibrary(folder, name)
+    library.module = require(library.bundle)
+    this._libraries[library.name] = library
+    return {
+      type: 'library',
+      name: name,
+      funcs: library.funcs
+    }
   }
 }
 

--- a/lib/contexts/NodeContext.js
+++ b/lib/contexts/NodeContext.js
@@ -1,9 +1,9 @@
-const Context = require('./Context')
+const JavascriptContext = require('./JavascriptContext')
 
 /**
  * A Node.js context for executing Javascript code
  */
-class NodeContext extends Context {
+class NodeContext extends JavascriptContext {
   executeBlock (block) {
     block.output.value = this.pack('Hello from Node.js. This is just a test!')
     return block

--- a/lib/host/Host.js
+++ b/lib/host/Host.js
@@ -385,6 +385,14 @@ class Host {
           throw new Error(`No method with name "${method}"`)
         }
       }
+    }).catch(error => {
+      return {
+        messages: [{
+          type: 'error',
+          message: error.message,
+          stack: error.stack
+        }]
+      }
     })
   }
 
@@ -790,6 +798,17 @@ class Host {
     }
 
     return body
+  }
+
+  /**
+   * Compile a library
+   *
+   * @param  {String} path Path to library folder
+   * @return {Object}     Library node including `bundle`, the path to the bundle created
+   */
+  async compile (path) {
+    const context = new NodeContext()
+    return context.compileLibrary(path)
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,13 @@ const version = pkg.version
 module.exports = {
   version: version,
   host: host,
+
   register: host.register.bind(host),
+
   start: host.start.bind(host),
   stop: host.stop.bind(host),
   run: host.run.bind(host),
-  spawn: host.spawn.bind(host)
+  spawn: host.spawn.bind(host),
+
+  compile: host.compile.bind(host)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,9 @@
       }
     },
     "acorn": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-      "dev": true
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -41,6 +40,15 @@
       "optional": true,
       "requires": {
         "acorn": "2.7.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "acorn-jsx": {
@@ -1173,7 +1181,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
       "requires": {
         "esutils": "2.0.2"
       }
@@ -1865,8 +1872,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -4003,6 +4009,15 @@
         "webidl-conversions": "2.0.1",
         "whatwg-url-compat": "0.6.5",
         "xml-name-validator": "2.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "jsesc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/acorn": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",
+      "integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
+      "requires": {
+        "@types/estree": "0.0.38"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
+      "integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -31,6 +44,14 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+    },
+    "acorn-dynamic-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "requires": {
+        "acorn": "5.5.3"
+      }
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -178,8 +199,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -810,6 +830,11 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -982,6 +1007,14 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "1.0.0"
+      }
+    },
+    "date-time": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+      "requires": {
+        "time-zone": "1.0.0"
       }
     },
     "debug": {
@@ -1869,6 +1902,11 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+      "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -2002,6 +2040,44 @@
         }
       }
     },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
     "expand-template": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
@@ -2122,6 +2198,11 @@
         "object-assign": "4.1.1"
       }
     },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2173,8 +2254,15 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -3217,6 +3305,38 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
     "glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -3624,6 +3744,11 @@
         "loose-envify": "1.3.1"
       }
     },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+    },
     "is-accessor-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
@@ -3659,8 +3784,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3719,11 +3843,23 @@
         }
       }
     },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -3783,7 +3919,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -3844,6 +3979,16 @@
         "isobject": "3.0.1"
       }
     },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -3855,6 +4000,14 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
+    },
+    "is-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.0.tgz",
+      "integrity": "sha512-h37O/IX4efe56o9k41II1ECMqKwtqHa7/12dLDEzJIFux2x15an4WCDb0/eKdmUgRpLJ3bR0DrzDc7vOrVgRDw==",
+      "requires": {
+        "@types/estree": "0.0.38"
+      }
     },
     "is-regex": {
       "version": "1.0.4",
@@ -4146,7 +4299,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
@@ -4193,6 +4345,11 @@
           }
         }
       }
+    },
+    "locate-character": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
+      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg=="
     },
     "locate-path": {
       "version": "2.0.0",
@@ -4870,7 +5027,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
       }
@@ -7776,6 +7932,15 @@
         "isobject": "3.0.1"
       }
     },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -7832,8 +7997,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -7864,6 +8028,32 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -7876,8 +8066,7 @@
     "parse-ms": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-      "dev": true
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
     },
     "parse5": {
       "version": "1.5.1",
@@ -8086,6 +8275,11 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
     "pretty-ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
@@ -8170,6 +8364,25 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -8296,6 +8509,14 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -8349,20 +8570,17 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
@@ -8420,6 +8638,11 @@
       "requires": {
         "lodash": "4.17.5"
       }
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -8484,6 +8707,134 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2"
+      }
+    },
+    "rollup": {
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
+      "integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
+      "requires": {
+        "@types/acorn": "4.0.3",
+        "acorn": "5.5.3",
+        "acorn-dynamic-import": "3.0.0",
+        "date-time": "2.1.0",
+        "is-reference": "1.1.0",
+        "locate-character": "2.0.5",
+        "pretty-ms": "3.1.0",
+        "require-relative": "0.8.7",
+        "rollup-pluginutils": "2.0.1",
+        "signal-exit": "3.0.2",
+        "sourcemap-codec": "1.4.1"
+      },
+      "dependencies": {
+        "plur": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+          "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+          "requires": {
+            "irregular-plurals": "1.4.0"
+          }
+        },
+        "pretty-ms": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
+          "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+          "requires": {
+            "parse-ms": "1.0.1",
+            "plur": "2.1.2"
+          }
+        }
+      }
+    },
+    "rollup-plugin-uglify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-3.0.0.tgz",
+      "integrity": "sha512-dehLu9eRRoV4l09aC+ySntRw1OAfoyKdbk8Nelblj03tHoynkSybqyEpgavemi1LBOH6S1vzI58/mpxkZIe1iQ==",
+      "requires": {
+        "uglify-es": "3.3.9"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+      "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+      "requires": {
+        "estree-walker": "0.3.1",
+        "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        }
       }
     },
     "run-async": {
@@ -8819,6 +9170,11 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz",
+      "integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA=="
     },
     "spawnteract": {
       "version": "4.0.0",
@@ -9441,11 +9797,15 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "time-zone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -9599,6 +9959,22 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
+    },
+    "uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "requires": {
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10078,6 +10078,11 @@
         }
       }
     },
+    "untildify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
+      "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+    },
     "upath": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,11 @@
     "tape": "^4.9.0"
   },
   "dependencies": {
+    "acorn": "^5.5.3",
     "address": "^1.0.3",
     "better-sqlite3": "^4.1.0",
     "body": "^5.1.0",
+    "doctrine": "^2.1.0",
     "execa": "^0.10.0",
     "get-stdin": "^6.0.0",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "cover": "nyc --reporter=lcov --reporter=text npm test",
     "docs": "esdoc",
     "start": "nodemon bin/stencila-nodemon.js",
-    "prepublishOnly": "npm run lint && npm run test && npm run check && npm run docs"
+    "prepublishOnly": "npm run lint && npm run test && npm run check && npm run docs",
+    "clean": "rimraf .nyc_output docs"
   },
   "repository": {
     "type": "git",
@@ -45,6 +46,7 @@
     "node-mocks-http": "^1.6.7",
     "nodemon": "^1.17.2",
     "nyc": "^11.6.0",
+    "rimraf": "^2.6.2",
     "standard": "^11.0.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.9.0"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "spawnteract": "^4.0.0",
     "sqlite-parser": "^1.0.1",
     "tmp": "0.0.33",
+    "untildify": "^3.0.2",
     "uuid": "^3.2.1"
   },
   "esdoc": {

--- a/package.json
+++ b/package.json
@@ -68,9 +68,12 @@
     "path-is-inside": "^1.0.2",
     "request": "^2.85.0",
     "request-promise": "^4.2.2",
+    "rollup": "^0.57.1",
+    "rollup-plugin-uglify": "^3.0.0",
     "send": "^0.15.4",
     "spawnteract": "^4.0.0",
     "sqlite-parser": "^1.0.1",
+    "tmp": "0.0.33",
     "uuid": "^3.2.1"
   },
   "esdoc": {

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -120,6 +120,7 @@ test('JavascriptContext.compileFunc', assert => {
     name: 'funcname',
     title: 'Function title',
     summary: 'Function summary',
+    description: 'Function description',
     examples: [
       'funcname(1, 2, 3, 4)',
       'funcname(x, y, z)'

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -86,6 +86,26 @@ test('JavascriptContext.compileFunc', assert => {
     'return description and type from docs'
   )
 
+  // Check example parsed from doc comment
+  assert.deepEqual(
+    context.compileFunc(`
+    /**
+     * @example func(ex1)
+     * @example <caption>Example 2 function</caption> func(ex2)
+     */
+    function func (a, b){}
+    `).examples,
+    [
+      {
+        usage: 'func(ex1)'
+      }, {
+        usage: 'func(ex2)',
+        caption: 'Example 2 function'
+      }
+    ],
+    'examples from docs'
+  )
+
   // Kitchen sink test
   const src = `
     /**
@@ -94,7 +114,7 @@ test('JavascriptContext.compileFunc', assert => {
      * @title Function title
      * @summary Function summary
      *
-     * @example
+     * @example <caption>Example caption</caption>
      *
      * funcname(1, 2, 3, 4)
      * 
@@ -122,8 +142,12 @@ test('JavascriptContext.compileFunc', assert => {
     summary: 'Function summary',
     description: 'Function description',
     examples: [
-      'funcname(1, 2, 3, 4)',
-      'funcname(x, y, z)'
+      {
+        usage: 'funcname(1, 2, 3, 4)',
+        caption: 'Example caption'
+      }, {
+        usage: 'funcname(x, y, z)'
+      }
     ],
     params: [
       {

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -21,7 +21,7 @@ test('JavascriptContext.compileFunc', assert => {
     assert.deepEqual(context.compileFunc(source).params, expect, message)
   }
 
-  checkParams('function func (){}', [], 'no parameters')
+  checkParams('function func (){}', undefined, 'no parameters')
   checkParams('function func (a){}', [{name: 'a'}], 'one parameter')
   checkParams('function func (a, b, c){}', [{name: 'a'}, {name: 'b'}, {name: 'c'}], 'three parameters')
 
@@ -68,24 +68,61 @@ test('JavascriptContext.compileFunc', assert => {
     'return description and type from docs'
   )
 
-  // Kitchensink test
-  assert.deepEqual(
-    context.compileFunc('function square(value){return value*value}'),
-    {
-      type: 'func',
-      source: {
-        type: 'text',
-        lang: 'js',
-        data: 'function square(value){return value*value}'
-      },
-      name: 'square',
-      params: [
-        {
-          name: 'value'
-        }
-      ]
+  // Kitchen sink test
+  const src = `
+    /**
+     * Function description
+     * 
+     * @title Function title
+     * @summary Function summary
+     *
+     * @example
+     *
+     * funcname(1, 2, 3, 4)
+     * 
+     * @example
+     *
+     * funcname(x, y, z)
+     *
+     * @param  {par1Type} par1 Parameter one description
+     * @param  {*} par2 Parameter two description
+     * @return {returnType} Return description
+     */
+    function funcname(par1, ...par2){
+      return par1 + sum(par2)
     }
-  )
+  `
+  assert.deepEqual(context.compileFunc(src), {
+    type: 'func',
+    source: {
+      type: 'text',
+      lang: 'js',
+      data: src
+    },
+    name: 'funcname',
+    title: 'Function title',
+    summary: 'Function summary',
+    examples: [
+      'funcname(1, 2, 3, 4)',
+      'funcname(x, y, z)'
+    ],
+    params: [
+      {
+        name: 'par1',
+        type: 'par1Type',
+        description: 'Parameter one description'
+      }, {
+        name: 'par2',
+        repeats: true,
+        type: 'any',
+        description: 'Parameter two description'
+      }
+    ],
+    return: {
+      type: 'returnType',
+      description: 'Return description'
+    }
+  })
 
   assert.end()
 })

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -46,6 +46,24 @@ test('JavascriptContext.compileFunc', assert => {
     {name: 'b', type: 'typeB', description: 'Description of parameter b'}
   ], 'parameter descriptions and types from docs')
 
+  checkParams(`
+    /**
+     * @param {...number} pars Description of parameters
+     */
+    function func (...pars){}
+  `, [
+    {name: 'pars', type: 'number', repeats: true, description: 'Description of parameters'}
+  ], 'repeatable parameter with type specified and elipses')
+
+  checkParams(`
+    /**
+     * @param {number} pars Description of parameters
+     */
+    function func (___pars){}
+  `, [
+    {name: 'pars', type: 'number', extends: true, description: 'Description of parameters'}
+  ], 'extensible parameter with type specified')
+
   // Check return parsed from doc comment
   function checkReturn (source, expect, message) {
     assert.deepEqual(context.compileFunc(source)['return'], expect, message)

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -1,0 +1,66 @@
+const test = require('tape')
+
+const JavascriptContext = require('../../lib/contexts/JavascriptContext')
+
+test('JavascriptContext', assert => {
+  const context = new JavascriptContext()
+
+  assert.ok(context instanceof JavascriptContext)
+  assert.end()
+})
+
+test('JavascriptContext.compileFunc', assert => {
+  let context = new JavascriptContext()
+
+  assert.deepEqual(
+    context.compileFunc('function square(value){return value*value}'),
+    {
+      type: 'func',
+      source: {
+        type: 'text',
+        lang: 'js',
+        data: 'function square(value){return value*value}'
+      },
+      name: 'square',
+      params: [
+        {
+          name: 'value'
+        }
+      ]
+    }
+  )
+
+  assert.throws(() => context.compileFunc(''), /No function definition found in the source code/, 'throws if no function defined')
+  assert.throws(() => context.compileFunc('foo bar()'), /Syntax error in source code: Unexpected token \(1:4\)/, 'throws if syntax error')
+
+  function checkParams (source, expect, message) {
+    assert.deepEqual(context.compileFunc(source).params, expect, message)
+  }
+
+  checkParams('function func (){}', [], 'no parameters')
+  checkParams('function func (a){}', [{name: 'a'}], 'one parameter')
+  checkParams('function func (a, b, c){}', [{name: 'a'}, {name: 'b'}, {name: 'c'}], 'three parameters')
+
+  checkParams('function func (...a){}', [{name: 'a', repeats: true}], 'one repeatable parameters')
+
+  checkParams('function func (___a){}', [{name: 'a', extends: true}], 'one extensible parameters')
+
+  // Currently, do not attempt to parse parameter defaults into values
+  checkParams('function func (a=1){}', [{name: 'a', default: '1'}], 'a parameter with a number default')
+  checkParams('function func (a="foo"){}', [{name: 'a', default: '"foo"'}], 'a parameter with a number default')
+  checkParams('function func (a=[1, 2, 3]){}', [{name: 'a', default: '[1, 2, 3]'}], 'a parameter with an array default')
+  checkParams('function func (a={b:1, c:2}){}', [{name: 'a', default: '{b:1, c:2}'}], 'a parameter with an array default')
+
+  checkParams(`
+    /**
+     * @param a Parameter a
+     * @param {typeB} b Parameter b
+     */
+    function func (a, b){}
+  `, [
+    {name: 'a', description: 'Parameter a'},
+    {name: 'b', type: 'typeB', description: 'Parameter b'}
+  ], 'parameter descriptions and types from docs')
+
+  assert.end()
+})

--- a/test/contexts/NodeContext.test.js
+++ b/test/contexts/NodeContext.test.js
@@ -5,15 +5,14 @@ const test = require('tape')
 const NodeContext = require('../../lib/contexts/NodeContext')
 
 test('NodeContext', assert => {
-  let context = new NodeContext()
+  const context = new NodeContext()
 
   assert.ok(context instanceof NodeContext)
   assert.end()
 })
 
 test('NodeContext.compileLibrary', async assert => {
-  let context = new NodeContext()
-
+  const context = new NodeContext()
   const libtest = path.join(__dirname, 'fixtures', 'libtest')
 
   await context.compileLibrary(libtest, null, false)
@@ -26,6 +25,17 @@ test('NodeContext.compileLibrary', async assert => {
   assert.ok(
     fs.statSync(path.join(libtest, 'libtest.min.js'))
   )
+
+  assert.end()
+})
+
+test('NodeContext.executeLibrary', async assert => {
+  const context = new NodeContext()
+  const libtest = path.join(__dirname, 'fixtures', 'libtest')
+
+  await context.executeLibrary(libtest, 'libtest')
+  const libs = await context.libraries()
+  assert.deepEqual(Object.keys(libs), ['libtest'])
 
   assert.end()
 })

--- a/test/contexts/NodeContext.test.js
+++ b/test/contexts/NodeContext.test.js
@@ -1,25 +1,31 @@
+const fs = require('fs')
+const path = require('path')
 const test = require('tape')
 
 const NodeContext = require('../../lib/contexts/NodeContext')
 
-test.skip('NodeContext', function (t) {
-  let c = new NodeContext()
+test('NodeContext', assert => {
+  let context = new NodeContext()
 
-  t.plan(4)
+  assert.ok(context instanceof NodeContext)
+  assert.end()
+})
 
-  t.ok(c instanceof NodeContext)
+test('NodeContext.compileLibrary', async assert => {
+  let context = new NodeContext()
 
-  c.runCode('foo = "bar"')
-    .then(() => {
-      c.runCode('foo + "t_simpson"')
-        .then(result => {
-          t.deepEqual(result, {errors: null, output: c.pack('bart_simpson')})
-        })
-    })
+  const libtest = path.join(__dirname, 'fixtures', 'libtest')
 
-  c.callCode('return a*6', {a: c.pack(7)}).then(result => {
-    t.deepEqual(result, {errors: null, output: c.pack(42)})
-  })
+  await context.compileLibrary(libtest, null, false)
+  assert.equal(
+    fs.readFileSync(path.join(libtest, 'libtest.js'), 'utf8'),
+    fs.readFileSync(path.join(libtest, 'expected-libtest.js'), 'utf8')
+  )
 
-  c.codeDependencies('foo').then(result => t.deepEqual(result, ['foo']))
+  await context.compileLibrary(libtest, null)
+  assert.ok(
+    fs.statSync(path.join(libtest, 'libtest.min.js'))
+  )
+
+  assert.end()
 })

--- a/test/contexts/NodeContext.test.js
+++ b/test/contexts/NodeContext.test.js
@@ -35,7 +35,7 @@ test('NodeContext.executeLibrary', async assert => {
 
   await context.executeLibrary(libtest, 'libtest')
   const libs = await context.libraries()
-  assert.deepEqual(Object.keys(libs), ['libtest'])
+  assert.deepEqual(Object.keys(libs), ['local', 'libtest'])
 
   assert.end()
 })

--- a/test/contexts/fixtures/libtest/.gitignore
+++ b/test/contexts/fixtures/libtest/.gitignore
@@ -1,0 +1,2 @@
+libtest.js
+libtest.min.js

--- a/test/contexts/fixtures/libtest/README.md
+++ b/test/contexts/fixtures/libtest/README.md
@@ -1,0 +1,3 @@
+This is a test function library for testing that `NodeContext.compileLibrary` works as expected.
+
+The file `expected-libtest.js` is the expected unminified bundle

--- a/test/contexts/fixtures/libtest/expected-libtest.js
+++ b/test/contexts/fixtures/libtest/expected-libtest.js
@@ -16,7 +16,7 @@
     return [a].concat(...b)
   }
 
-  const FUNCS = {
+  const LIBRARY = {
     "func1": {
       "type": "func",
       "name": "func1"
@@ -37,7 +37,7 @@
     }
   };
 
-  exports.FUNCS = FUNCS;
+  exports.LIBRARY = LIBRARY;
   exports.func1 = func1;
   exports.func2 = func2;
 

--- a/test/contexts/fixtures/libtest/expected-libtest.js
+++ b/test/contexts/fixtures/libtest/expected-libtest.js
@@ -16,30 +16,29 @@
     return [a].concat(...b)
   }
 
-  const LIBRARY = {
-    "func1": {
-      "type": "func",
-      "name": "func1"
-    },
-    "func2": {
-      "type": "func",
-      "description": "A function with a repeatable parameter\n and this JsDoc string",
-      "name": "func2",
-      "params": [
-        {
-          "name": "a"
-        },
-        {
-          "name": "b",
-          "repeats": true
-        }
-      ]
-    }
+  const func1$1 = {
+    "type": "func",
+    "name": "func1"
   };
+  func1$1.body = func1;
+  const func2$1 = {
+    "type": "func",
+    "description": "A function with a repeatable parameter\n and this JsDoc string",
+    "name": "func2",
+    "params": [
+      {
+        "name": "a"
+      },
+      {
+        "name": "b",
+        "repeats": true
+      }
+    ]
+  };
+  func2$1.body = func2;
 
-  exports.LIBRARY = LIBRARY;
-  exports.func1 = func1;
-  exports.func2 = func2;
+  exports.func1 = func1$1;
+  exports.func2 = func2$1;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/contexts/fixtures/libtest/expected-libtest.js
+++ b/test/contexts/fixtures/libtest/expected-libtest.js
@@ -1,0 +1,46 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (factory((global.local = {})));
+}(this, (function (exports) { 'use strict';
+
+  // A function without a JSDoc string
+
+  function func1 () {}
+
+  /**
+   * A function with a repeatable parameter
+   * and this JsDoc string
+   */
+  function func2 (a, ...b) {
+    return [a].concat(...b)
+  }
+
+  const FUNCS = {
+    "func1": {
+      "type": "func",
+      "name": "func1"
+    },
+    "func2": {
+      "type": "func",
+      "description": "A function with a repeatable parameter\n and this JsDoc string",
+      "name": "func2",
+      "params": [
+        {
+          "name": "a"
+        },
+        {
+          "name": "b",
+          "repeats": true
+        }
+      ]
+    }
+  };
+
+  exports.FUNCS = FUNCS;
+  exports.func1 = func1;
+  exports.func2 = func2;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/contexts/fixtures/libtest/funcs/func1.js
+++ b/test/contexts/fixtures/libtest/funcs/func1.js
@@ -1,0 +1,3 @@
+// A function without a JSDoc string
+
+export default function func1 () {}

--- a/test/contexts/fixtures/libtest/funcs/func2.js
+++ b/test/contexts/fixtures/libtest/funcs/func2.js
@@ -1,0 +1,7 @@
+/**
+ * A function with a repeatable parameter
+ * and this JsDoc string
+ */
+export default function func2 (a, ...b) {
+  return [a].concat(...b)
+}


### PR DESCRIPTION
Adds `JavascriptContext` that makes it easier for function developers to write and test Javascript functions.

- [x] can compile Javascript function source code, including documentation comments, into a function specification (ie. an object with `name`, `description`, `params` etc). This will replace the [`FunctionJsDocConverter` in the stencila/convert repo](https://github.com/stencila/convert/blob/master/src/function/FunctionJsDocConverter.js) and allow 'hot loading' functions into execution contexts.

- [x] can execute a function call by mapping call arguments onto function parameters (ie. dealing with variadic and keyword arguments). This will replace the implementation in the proposed [`execute` function in libcore](https://github.com/stencila/libcore/pull/18/files#diff-aa7d50709c13c49428414045a328bbb3R38).

