### PR TITLE
Upgrades to SqliteContext

### DIFF
--- a/lib/contexts/SqliteContext.js
+++ b/lib/contexts/SqliteContext.js
@@ -199,6 +199,13 @@ class SqliteContext extends Context {
       }
       sql = this._interpolateSql(sql, inputs).sql
 
+      // Create temporary views to input tables
+      for (let [name, value] of Object.entries(inputs)) {
+        if (value && value.table) {
+          this._db.exec(`CREATE TEMPORARY VIEW ${name} AS SELECT * FROM ${value.table}`)
+        }
+      }
+
       let valueSql
       if (cell.expr) {
         // Output value of expression is just the expression
@@ -229,6 +236,13 @@ class SqliteContext extends Context {
       if (name) output.name = name
       if (value) output.value = value
       cell.outputs = [output]
+
+      // Destroy views to input tables
+      for (let [name, value] of Object.entries(inputs)) {
+        if (value && value.table) {
+          this._db.exec(`DROP VIEW IF EXISTS ${name}`)
+        }
+      }
 
       return cell
     } catch (error) {
@@ -325,7 +339,7 @@ class SqliteContext extends Context {
       let rows = data[cols[0]].length
       this._db.exec(`DROP TABLE IF EXISTS inputs.${name}`)
       this._db.exec(`CREATE TABLE inputs.${name} (${cols.join(', ')})`)
-      let statement = this._db.prepare(`INSERT INTO inputs.${name} VALUES (${Array(cols.length).fill('?').join(',')})`)
+      let statement = this._db.prepare(`INSERT INTO ${name} VALUES (${Array(cols.length).fill('?').join(',')})`)
       for (let row = 0; row < rows; row++) {
         let rowData = []
         for (let col of cols) rowData.push(data[col][row])


### PR DESCRIPTION
This fixes some bugs in `SqliteContext`.

In particular, one bug related to using a `VIEW` for each input. It turns out this is not needed becuase of the way name resolution works with attached databases. From https://www.sqlite.org/lang_attach.html

"Tables in an attached database can be referred to using the syntax 
schema-name.table-name. **If the name of the table is unique across all 
attached databases and the main and temp databases, then the schema-name
 prefix is not required**. If two or more tables in different databases 
 have the same name and the schema-name prefix is not used on a table 
 reference, then the table chosen is the one in the database that was 
 least recently attached."

So we don't need a view (although name clash with existing database table
may still exist).