### PR TITLE
Upgrades to JavascriptContext

### DIFF
--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -80,7 +80,7 @@ class JavascriptContext extends Context {
     // A code expression to execute to get the return value
     // (only used internally as an optimisation when
     // called by `this.execute()`)
-    let _expr = null
+    let _return = null
 
     // Error messages
     let messages = []
@@ -153,27 +153,37 @@ class JavascriptContext extends Context {
       // VariableDeclaration or Identifier then use it's name as the output name
       let last = ast.body.pop()
       if (last) {
-        if (last.type === 'FunctionDeclaration') {
-          name = last.id.name
-          value = this._compileFunction(name, last, source, docs)
-        } else if (last.type === 'ExportDefaultDeclaration') {
-          // Currently, only handle exported functions
-          const decl = last.declaration
-          if (decl.type === 'FunctionDeclaration') {
-            name = decl.id.name
-            value = this._compileFunction(name, decl, source, docs)
-          }
-        } else if (last.type === 'VariableDeclaration') {
-          name = last.declarations[0].id.name
-          _expr = name
-        } else if (last.type === 'ExpressionStatement') {
-          if (last.expression.type === 'Identifier') {
-            name = last.expression.name
-          }
-          _expr = generate(last)
-        } else {
-          // During development it can be useful to turn this on
-          // throw new Error('Unhandled AST node type: ' + last.type)
+        switch (last.type) {
+          case 'FunctionDeclaration':
+            name = last.id.name
+            value = this._compileFunction(name, last, source, docs)
+            _return = name
+            break
+          case 'ExportDefaultDeclaration':
+            // Currently, only handle exported functions
+            const decl = last.declaration
+            if (decl.type === 'FunctionDeclaration') {
+              name = decl.id.name
+              value = this._compileFunction(name, decl, source, docs)
+              _return = name
+            }
+            break
+          case 'VariableDeclaration':
+            name = last.declarations[0].id.name
+            _return = name
+            break
+          case 'ExpressionStatement':
+            if (last.expression.type === 'Identifier') {
+              name = last.expression.name
+            }
+            _return = generate(last)
+            break
+          case 'BlockStatement':
+          case 'IfStatement':
+            break
+          default:
+            // During development it can be useful to turn this on
+            throw new Error('Unhandled AST node type: ' + last.type)
         }
       }
     }
@@ -181,7 +191,7 @@ class JavascriptContext extends Context {
     let output = {}
     if (name) output.name = name
     if (value) output.value = await this.pack(value)
-    let outputs = (name || value || _expr) ? [output] : []
+    let outputs = (name || value || _return) ? [output] : []
 
     const compiled = {
       type: 'cell',
@@ -193,9 +203,8 @@ class JavascriptContext extends Context {
       outputs,
       messages
     }
-    if (internal) {
-      compiled._expr = _expr
-    }
+    if (internal) compiled._return = _return
+
     return compiled
   }
 
@@ -351,24 +360,80 @@ class JavascriptContext extends Context {
   }
 
   async execute (cell) {
-    cell = await this.compile(cell)
+    // At present, the received cell may not have
+    // all the things we need (e.g. outputs etc) from a
+    // previous compilation step. So we compile the cell
+    // and extract those from there. Only `inputs` (with values)
+    // are taken from the received cell
+    let compiled = await this.compile(cell, true)
+    cell = {
+      source: compiled.source,
+      expr: cell.expr || false,
+      inputs: cell.inputs || [],
+      outputs: compiled.outputs,
+      messages: compiled.messages
+    }
 
-    for (let output of cell.outputs || []) {
-      let value = await this.unpack(output.value)
-      if (value.type === 'function') {
-        // 'Execute' a function defintition by evaluating it's source code and
-        // putting it into the 'local' library
-        let source = cell.source.data
-        value.body = eval(source + ';' + value.name) // eslint-disable-line no-eval
+    // Get cell source code adding the return value of function to the code
+    // (i.e. simulate implicit return). Although this approach is inefficient,
+    // because it involves executing expressions twice, it
+    // has the advantage of accurately reporting errors in the correct location
+    // in the cell's source code. Other approaches can be investigated later.
+    let source = cell.source.data + `;\nreturn ${compiled._return};`
 
+    // Get the names and values of cell inputs
+    let inputNames = []
+    let inputValues = []
+    for (let input of cell.inputs) {
+      if (!input.name) throw new Error(`Name is required for input`)
+      if (!input.value) throw new Error(`Value is required for input "${input.name}"`)
+      inputNames.push(input.name)
+      inputValues.push(await this.unpack(input.value))
+    }
+
+    // Construct a function from them
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+    const func = new AsyncFunction(...inputNames, source) // eslint-disable-line no-new-func
+
+    // Execute the function, using input values as arguments
+    // an converting exceptions into error messages
+    let value
+    try {
+      value = await func(...inputValues)
+    } catch (error) {
+      let line = 0
+      let column = 0
+      let message
+      if (error.stack) {
+        // Parse the error stack to get message, line and columns numbers
+        let lines = error.stack.split('\n')
+        let match = lines[1].match(/<anonymous>:(\d+):(\d+)/)
+        if (match) {
+          line = parseInt(match[1], 10) - 2
+          column = parseInt(match[2], 10)
+        }
+        message = lines[0] || error.message
+      }
+      cell.messages.push({
+        type: 'error',
+        line: line,
+        column: column,
+        message: message
+      })
+    }
+
+    if (value) {
+      if (typeof value === 'function') {
+        // Output value is a function so register it in local library
+        let func = await this.unpack(cell.outputs[0].value)
+        func.body = value
         if (!this._libraries['local']) this._libraries['local'] = {}
-        this._libraries['local'][value.name] = value
+        this._libraries['local'][func.name] = func
+      } else {
+        cell.outputs[0].value = await this.pack(value)
       }
     }
-    // const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
-    // const func = new AsyncFunction('return ' + code) // eslint-disable-line no-new-func
-    // const value = await func()
-    // cell.output = { value: this.pack(value) }
+
     return cell
   }
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -1,5 +1,6 @@
 const acorn = require('acorn')
 const doctrine = require('doctrine')
+const { generate } = require('astring')
 const walk = require('acorn/dist/walk')
 
 const Context = require('./Context')
@@ -36,6 +37,7 @@ class JavascriptContext extends Context {
    * Compile a cell
    */
   async compile (cell) {
+    // Cell source code
     let source
     if (typeof cell === 'string' || cell instanceof String) {
       source = cell
@@ -45,7 +47,17 @@ class JavascriptContext extends Context {
       source = cell.source.data
     }
 
-    // Parse the source code collecting any comments
+    // Input values
+    let inputs = []
+
+    // Output name and value (currently assuming a single output)
+    let name
+    let value
+
+    // Error messages
+    let messages = []
+
+    // Parse the source code (including comments for function definitions)
     let ast
     let docs = []
     try {
@@ -56,21 +68,89 @@ class JavascriptContext extends Context {
         }
       })
     } catch (error) {
-      throw new Error('Syntax error in source code: ' + error.message)
+      let line = 0
+      let column = 0
+      if (error instanceof SyntaxError && error.loc) {
+        line = error.loc.line
+        column = error.loc.column
+      }
+      messages.push({
+        type: 'error',
+        message: 'Syntax error in Javascript: ' + error.message,
+        line,
+        column
+      })
     }
     if (docs.length === 0) docs.push(null)
 
-    // Extract the first `FunctionDeclaration` from the AST.
-    let decl
-    walk.simple(ast, {
-      FunctionDeclaration (node) {
-        if (!decl) decl = node
-      }
-    })
-    if (!decl) throw new Error('No function definition found in the source code')
+    if (messages.length === 0) {
+      // Determine which names are declared and which are used
+      let declared = []
+      walk.simple(ast, {
+        FunctionDeclaration (node) {
+          declared.push(node.id.name)
+        },
+        VariableDeclarator: node => {
+          declared.push(node.id.name)
+        },
+        Identifier: node => {
+          let name = node.name
+          if (declared.indexOf(name) < 0) inputs.push({ name })
+        }
+      })
 
-    // Function name is ALWAYS the first function declared in the code
-    const name = decl.id.name
+      // If the last top level node in the AST is a FunctionDeclaration,
+      // VariableDeclaration or Identifier then use it's name as the output name
+      let last = ast.body.pop()
+      if (last) {
+        if (last.type === 'FunctionDeclaration') {
+          name = last.id.name
+          value = this._compileFunction(name, last, source, docs)
+        } else if (last.type === 'ExportDefaultDeclaration') {
+          // Currenly only handle exported functions
+          const decl = last.declaration
+          if (decl.type === 'FunctionDeclaration') {
+            name = decl.id.name
+            value = this._compileFunction(name, decl, source, docs)
+          }
+        } else if (last.type === 'VariableDeclaration') {
+          name = last.declarations[0].id.name
+          value = name
+        } else if (last.type === 'ExpressionStatement') {
+          if (last.expression.type === 'Identifier') {
+            name = last.expression.name
+          }
+          value = generate(last)
+        } else {
+          // During development it can be useful to turn this on
+          // throw new Error('Unhandled AST node type: ' + last.type)
+        }
+      }
+    }
+
+    let output = {}
+    if (name) output.name = name
+    if (value) output.value = await this.pack(value)
+    let outputs = Object.keys(output).length ? [output] : []
+
+    return {
+      type: 'cell',
+      source: {
+        type: 'text',
+        lang: 'js',
+        data: source
+      },
+      inputs: inputs,
+      outputs: outputs,
+      messages: messages
+    }
+  }
+
+  _compileFunction (name, decl, source, docs) {
+    let func = {
+      type: 'function',
+      name: name
+    }
 
     // Extract the type specification for a `@param` or `@return` tag
     function _extractType (tag) {
@@ -91,11 +171,6 @@ class JavascriptContext extends Context {
         default:
           throw new Error('Unhandled type specification: ' + tag.type.type)
       }
-    }
-
-    let func = {
-      type: 'function',
-      name: name
     }
 
     let methods = {}
@@ -219,20 +294,7 @@ class JavascriptContext extends Context {
 
     func.methods = methods
 
-    return {
-      type: 'cell',
-      source: {
-        type: 'text',
-        lang: 'js',
-        data: source
-      },
-      inputs: [],
-      outputs: [{
-        name: name,
-        value: await this.pack(func)
-      }],
-      messages: []
-    }
+    return func
   }
 
   async execute (cell) {

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -138,10 +138,10 @@ class JavascriptContext extends Context {
         FunctionDeclaration (node) {
           declared.push(node.id.name)
         },
-        VariableDeclarator: node => {
+        VariableDeclarator (node) {
           declared.push(node.id.name)
         },
-        Identifier: node => {
+        Identifier (node) {
           let name = node.name
           if (declared.indexOf(name) < 0 && GLOBALS.indexOf(name) < 0) {
             inputs.push({ name })
@@ -336,7 +336,9 @@ class JavascriptContext extends Context {
       }
 
       if (params.length || return_ || examples.length) {
-        let signature = name + '(' + params.map(param => `${param.name}: ${param.type}`).join(', ') + ')'
+        let signature = name + '(' + params.map(param => {
+          return param.name + (param.type ? `: ${param.type}` : '')
+        }).join(', ') + ')'
         if (return_) signature += `: ${return_.type}`
         method.signature = signature
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -6,6 +6,26 @@ const walk = require('acorn/dist/walk')
 const Context = require('./Context')
 
 /**
+ * Global variable names that should be ignored when determining
+ * cell inputs with the `compile()` method
+ *
+ * @type {Array}
+ */
+const GLOBALS = [
+  // A list of ES6 globals obtained using: Object.keys(require('globals').es6)
+  'Array', 'ArrayBuffer', 'Boolean', 'constructor', 'DataView', 'Date', 'decodeURI', 'decodeURIComponent',
+  'encodeURI', 'encodeURIComponent', 'Error', 'escape', 'eval', 'EvalError', 'Float32Array', 'Float64Array',
+  'Function', 'hasOwnProperty', 'Infinity', 'Int16Array', 'Int32Array', 'Int8Array', 'isFinite', 'isNaN',
+  'isPrototypeOf', 'JSON', 'Map', 'Math', 'NaN', 'Number', 'Object', 'parseFloat', 'parseInt', 'Promise',
+  'propertyIsEnumerable', 'Proxy', 'RangeError', 'ReferenceError', 'Reflect', 'RegExp', 'Set', 'String',
+  'Symbol', 'SyntaxError', 'System', 'toLocaleString', 'toString', 'TypeError', 'Uint16Array', 'Uint32Array',
+  'Uint8Array', 'Uint8ClampedArray', 'undefined', 'unescape', 'URIError', 'valueOf', 'WeakMap', 'WeakSet',
+  // A list of Node.js globals obtained using: Object.keys(require('globals').node)
+  '__dirname', '__filename', 'arguments', 'Buffer', 'clearImmediate', 'clearInterval', 'clearTimeout', 'console',
+  'exports', 'GLOBAL', 'global', 'Intl', 'module', 'process', 'require', 'root', 'setImmediate', 'setInterval', 'setTimeout'
+]
+
+/**
  * An execution context for Javascript
  *
  * Although this currently resides in the `stencila/node` repository,
@@ -123,7 +143,9 @@ class JavascriptContext extends Context {
         },
         Identifier: node => {
           let name = node.name
-          if (declared.indexOf(name) < 0) inputs.push({ name })
+          if (declared.indexOf(name) < 0 && GLOBALS.indexOf(name) < 0) {
+            inputs.push({ name })
+          }
         }
       })
 
@@ -164,8 +186,7 @@ class JavascriptContext extends Context {
     const compiled = {
       type: 'cell',
       source: {
-        type: 'text',
-        lang: 'js',
+        type: 'string',
         data: source
       },
       inputs,

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -133,15 +133,25 @@ class JavascriptContext extends Context {
 
     if (messages.length === 0) {
       // Determine which names are declared and which are used
+      // do not enter some nodes like blocks and function declarations
+      // because we only want to pick up top level declarations and
+      // identifers
       let declared = []
-      walk.simple(ast, {
-        FunctionDeclaration (node) {
+      walk.recursive(ast, {}, {
+        BlockStatement (node, state, contin) {},
+        // For statements contain variable declarations we wish to ignore
+        ForStatement (node, state, contin) {},
+        ForInStatement (node, state, contin) {},
+        ForOfStatement (node, state, contin) {},
+        FunctionDeclaration (node, state, contin) {
           declared.push(node.id.name)
         },
-        VariableDeclarator (node) {
+        VariableDeclarator (node, state, contin) {
           declared.push(node.id.name)
+          // Recurse into initializer
+          if (node.init) contin(node.init, state)
         },
-        Identifier (node) {
+        Identifier (node, state, contin) {
           let name = node.name
           if (declared.indexOf(name) < 0 && GLOBALS.indexOf(name) < 0) {
             inputs.push({ name })

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -36,7 +36,7 @@ class JavascriptContext extends Context {
   /**
    * Compile a cell
    */
-  async compile (cell) {
+  async compile (cell, internal = false) {
     // Cell source code
     let source
     if (typeof cell === 'string' || cell instanceof String) {
@@ -55,8 +55,9 @@ class JavascriptContext extends Context {
     let value
 
     // A code expression to execute to get the return value
-    // (not applicable to function outputs)
-    let _result = null
+    // (only used internally as an optimisation when
+    // called by `this.execute()`)
+    let _expr = null
 
     // Error messages
     let messages = []
@@ -111,7 +112,7 @@ class JavascriptContext extends Context {
           name = last.id.name
           value = this._compileFunction(name, last, source, docs)
         } else if (last.type === 'ExportDefaultDeclaration') {
-          // Currenly only handle exported functions
+          // Currently, only handle exported functions
           const decl = last.declaration
           if (decl.type === 'FunctionDeclaration') {
             name = decl.id.name
@@ -119,12 +120,12 @@ class JavascriptContext extends Context {
           }
         } else if (last.type === 'VariableDeclaration') {
           name = last.declarations[0].id.name
-          _result = name
+          _expr = name
         } else if (last.type === 'ExpressionStatement') {
           if (last.expression.type === 'Identifier') {
             name = last.expression.name
           }
-          _result = generate(last)
+          _expr = generate(last)
         } else {
           // During development it can be useful to turn this on
           // throw new Error('Unhandled AST node type: ' + last.type)
@@ -135,9 +136,9 @@ class JavascriptContext extends Context {
     let output = {}
     if (name) output.name = name
     if (value) output.value = await this.pack(value)
-    let outputs = Object.keys(output).length ? [output] : []
+    let outputs = (name || value || _expr) ? [output] : []
 
-    return {
+    const compiled = {
       type: 'cell',
       source: {
         type: 'text',
@@ -148,6 +149,10 @@ class JavascriptContext extends Context {
       outputs,
       messages
     }
+    if (internal) {
+      compiled._expr = _expr
+    }
+    return compiled
   }
 
   _compileFunction (name, decl, source, docs) {

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -54,6 +54,10 @@ class JavascriptContext extends Context {
     let name
     let value
 
+    // A code expression to execute to get the return value
+    // (not applicable to function outputs)
+    let _result = null
+
     // Error messages
     let messages = []
 
@@ -115,12 +119,12 @@ class JavascriptContext extends Context {
           }
         } else if (last.type === 'VariableDeclaration') {
           name = last.declarations[0].id.name
-          value = name
+          _result = name
         } else if (last.type === 'ExpressionStatement') {
           if (last.expression.type === 'Identifier') {
             name = last.expression.name
           }
-          value = generate(last)
+          _result = generate(last)
         } else {
           // During development it can be useful to turn this on
           // throw new Error('Unhandled AST node type: ' + last.type)
@@ -140,9 +144,9 @@ class JavascriptContext extends Context {
         lang: 'js',
         data: source
       },
-      inputs: inputs,
-      outputs: outputs,
-      messages: messages
+      inputs,
+      outputs,
+      messages
     }
   }
 

--- a/lib/contexts/JavascriptContext.js
+++ b/lib/contexts/JavascriptContext.js
@@ -47,6 +47,9 @@ class JavascriptContext extends Context {
       source = cell.source.data
     }
 
+    // Should source be a simple expression?
+    const exprOnly = cell.expr || false
+
     // Input values
     let inputs = []
 
@@ -87,6 +90,26 @@ class JavascriptContext extends Context {
       })
     }
     if (docs.length === 0) docs.push(null)
+
+    // Check for single expression only
+    // Only allow simple expressions
+    // See http://esprima.readthedocs.io/en/latest/syntax-tree-format.html#expressions-and-patterns
+    // for a list of expression types
+    if (messages.length === 0 && exprOnly) {
+      try {
+        if (ast.body.length > 1) throw new Error()
+        const first = ast.body[0]
+        if (!first) throw new Error()
+        if (first.type !== 'ExpressionStatement') throw new Error()
+        const dissallowed = ['AssignmentExpression', 'UpdateExpression', 'AwaitExpression', 'Super']
+        if (dissallowed.indexOf(first.expression.type) >= 0) throw new Error()
+      } catch (error) {
+        messages.push({
+          type: 'error',
+          message: 'Cell source code must be a single, simple Javascript expression'
+        })
+      }
+    }
 
     if (messages.length === 0) {
       // Determine which names are declared and which are used

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stencila-node",
-  "version": "0.28.5",
+  "version": "0.28.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -265,6 +265,11 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
+    },
+    "astring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.2.0.tgz",
+      "integrity": "sha512-k56RHONVedeLvo2bOh640l6Hn5MtnDFLPsRFq4L5O6ts7mJNBGssYA32ju8LXBIqXk9zY12iKY6m2dnW0qGH/g=="
     },
     "async": {
       "version": "1.5.2",
@@ -3909,11 +3914,6 @@
         "is-path-inside": "1.0.1"
       }
     },
-    "is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
-    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -4507,14 +4507,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/lzz-gyp/-/lzz-gyp-0.4.2.tgz",
       "integrity": "sha1-SVxEA0ofUMSKYPDvnCjUJ2Olspc="
-    },
-    "magic-string": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
-      "requires": {
-        "vlq": "0.2.3"
-      }
     },
     "make-dir": {
       "version": "1.2.0",
@@ -8130,7 +8122,8 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -8670,6 +8663,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -8754,41 +8748,6 @@
             "parse-ms": "1.0.1",
             "plur": "2.1.2"
           }
-        }
-      }
-    },
-    "rollup-plugin-commonjs": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.0.tgz",
-      "integrity": "sha512-NrfE0g30QljNCnlJr7I2Xguz+44mh0dCxvfxwLnCwtaCK2LwFUp1zzAs8MQuOfhH4mRskqsjfOwGUap/L+WtEw==",
-      "requires": {
-        "estree-walker": "0.5.1",
-        "magic-string": "0.22.5",
-        "resolve": "1.5.0",
-        "rollup-pluginutils": "2.0.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.1.tgz",
-          "integrity": "sha512-7HgCgz1axW7w5aOvgOQkoR1RMBkllygJrssU3BvymKQ95lxXYv6Pon17fBRDm9qhkvXZGijOULoSF9ShOk/ZLg=="
-        }
-      }
-    },
-    "rollup-plugin-node-resolve": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz",
-      "integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
-      "requires": {
-        "builtin-modules": "2.0.0",
-        "is-module": "1.0.0",
-        "resolve": "1.5.0"
-      },
-      "dependencies": {
-        "builtin-modules": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
-          "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg=="
         }
       }
     },
@@ -10196,11 +10155,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
-    },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     },
     "webidl-conversions": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "acorn": "^5.5.3",
     "address": "^1.0.3",
+    "astring": "^1.2.0",
     "better-sqlite3": "^4.1.0",
     "body": "^5.1.0",
     "doctrine": "^2.1.0",

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -17,8 +17,7 @@ testAsync('JavascriptContext.compile', async assert => {
   assert.deepEqual(await context.compile(''), {
     type: 'cell',
     source: {
-      type: 'text',
-      lang: 'js',
+      type: 'string',
       data: ''
     },
     inputs: [],
@@ -31,8 +30,7 @@ testAsync('JavascriptContext.compile', async assert => {
   assert.deepEqual(await context.compile('foo bar()'), {
     type: 'cell',
     source: {
-      type: 'text',
-      lang: 'js',
+      type: 'string',
       data: 'foo bar()'
     },
     inputs: [],
@@ -55,10 +53,30 @@ testAsync('JavascriptContext.compile', async assert => {
     )
   }
 
+  // Global variables are not inputs
+  check('Math.pi', {
+    inputs: [],
+    outputs: [{}]
+  })
+  check('const foo = require("foo")\nfoo.bar', {
+    inputs: [],
+    outputs: [{}]
+  })
+
+  // Non-global, undeclared variables are inputs
+  check('const result = specialFunc()', {
+    inputs: [{name: 'specialFunc'}],
+    outputs: [{name: 'result'}]
+  })
+  check('specialMath.pi', {
+    inputs: [{name: 'specialMath'}],
+    outputs: [{}]
+  })
+
   // Last statement is an undeclared variable
   check('foo', {
-    inputs: [ {name: 'foo'} ],
-    outputs: [ {name: 'foo'} ]
+    inputs: [{name: 'foo'}],
+    outputs: [{name: 'foo'}]
   })
 
   // Last statement is a declaration
@@ -77,22 +95,22 @@ testAsync('JavascriptContext.compile', async assert => {
 
   check('var foo\nfoo', {
     inputs: [],
-    outputs: [ {name: 'foo'} ]
+    outputs: [{name: 'foo'}]
   })
 
   check('let foo\nfoo', {
     inputs: [],
-    outputs: [ {name: 'foo'} ]
+    outputs: [{name: 'foo'}]
   })
 
   check('const foo = 1\nfoo', {
     inputs: [],
-    outputs: [ {name: 'foo'} ]
+    outputs: [{name: 'foo'}]
   })
 
   check('var foo = 1\nfoo', {
     inputs: [],
-    outputs: [ {name: 'foo'} ]
+    outputs: [{name: 'foo'}]
   })
 
   // Last statement is a declaration with multiple declarations (first identifier used)
@@ -211,7 +229,8 @@ testAsync('JavascriptContext.compile function', async assert => {
     {
       type: 'cell',
       source: {
-        type: 'text', lang: 'js', data: 'function afunc() {}'
+        type: 'string',
+        data: 'function afunc() {}'
       },
       inputs: [],
       outputs: [{

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -121,10 +121,18 @@ testAsync('JavascriptContext.compile', async assert => {
     outputs: [{name: 'baz'}]
   })
 
-  // Last statement is not a declaration or identifier
-  await check('let foo\n{bar\nlet baz}', {
-    inputs: [{name: 'bar'}],
-    outputs: []
+  // Only top level variable declarations are considered when
+  // determining cell inputs
+  await check(`
+    let a;
+    {var c};
+    for (let b in [1,2,3]){};
+    if (true) { const d = 1 };
+    function f () { let e = 2 };
+    a * b * c * d * e;
+  `, {
+    inputs: [{name: 'b'}, {name: 'c'}, {name: 'd'}, {name: 'e'}],
+    outputs: [{}]
   })
 
   // Last statement is not a declaration or identifier
@@ -239,7 +247,7 @@ testAsync('JavascriptContext.compile function', async assert => {
         type: 'string',
         data: 'function afunc(x, y) { return x * y }'
       },
-      inputs: [ { name: 'x' }, { name: 'y' } ],
+      inputs: [],
       outputs: [{
         name: 'afunc',
         value: {

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -13,9 +13,7 @@ test('JavascriptContext', assert => {
 testAsync('JavascriptContext.compile', async assert => {
   let context = new JavascriptContext()
 
-  assert.deepEqual(
-    await context.compile(''),
-    {
+  assert.deepEqual(await context.compile(''), {
       type: 'cell',
       source: {
         type: 'text',
@@ -28,9 +26,7 @@ testAsync('JavascriptContext.compile', async assert => {
     }
   )
 
-  assert.deepEqual(
-    await context.compile('foo bar()'),
-    {
+  assert.deepEqual(await context.compile('foo bar()'), {
       type: 'cell',
       source: {
         type: 'text',
@@ -47,6 +43,40 @@ testAsync('JavascriptContext.compile', async assert => {
       }]
     }
   )
+
+  async function check(source, expected) {
+    const result = await context.compile(source)
+    assert.deepEqual(
+      (({inputs, outputs}) => ({inputs, outputs}))(result),
+      expected,
+      source
+    )
+  }
+
+  check('foo', {
+    inputs: [ {name: 'foo'} ],
+    outputs: [ {name: 'foo'} ]
+  })
+
+  check('var foo\nfoo', {
+    inputs: [],
+    outputs: [ {name: 'foo'} ]
+  })
+
+  check('let foo\nfoo', {
+    inputs: [],
+    outputs: [ {name: 'foo'} ]
+  })
+
+  check('const foo = 1\nfoo', {
+    inputs: [],
+    outputs: [ {name: 'foo'} ]
+  })
+
+  check('var foo = 1\nfoo', {
+    inputs: [],
+    outputs: [ {name: 'foo'} ]
+  })
 
   assert.end()
 })

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -1,5 +1,6 @@
 const test = require('tape')
 
+const { testAsync } = require('../helpers')
 const JavascriptContext = require('../../lib/contexts/JavascriptContext')
 
 test('JavascriptContext', assert => {
@@ -9,21 +10,49 @@ test('JavascriptContext', assert => {
   assert.end()
 })
 
-test('JavascriptContext.compile function', async assert => {
+testAsync('JavascriptContext.compile', async assert => {
   let context = new JavascriptContext()
 
-  // Test that bad inputs are handled OK
-  try {
-    await context.compile('')
-  } catch (error) {
-    assert.ok(error.message.match(/^No function definition found in the source code/), 'throws if no function defined')
-  }
-  try {
-    await context.compile('foo bar()')
-    assert.fail('shouldn\'t get here')
-  } catch (error) {
-    assert.pass('throws if syntax error')
-  }
+  assert.deepEqual(
+    await context.compile(''),
+    {
+      type: 'cell',
+      source: {
+        type: 'text',
+        lang: 'js',
+        data: ''
+      },
+      inputs: [],
+      outputs: [],
+      messages: []
+    }
+  )
+
+  assert.deepEqual(
+    await context.compile('foo bar()'),
+    {
+      type: 'cell',
+      source: {
+        type: 'text',
+        lang: 'js',
+        data: 'foo bar()'
+      },
+      inputs: [],
+      outputs: [],
+      messages: [{
+        type: 'error',
+        message: 'Syntax error in Javascript: Unexpected token (1:4)',
+        line: 1,
+        column: 4
+      }]
+    }
+  )
+
+  assert.end()
+})
+
+testAsync('JavascriptContext.compile function', async assert => {
+  let context = new JavascriptContext()
 
   function afunc () {}
   assert.deepEqual(

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -54,110 +54,117 @@ testAsync('JavascriptContext.compile', async assert => {
   }
 
   // Global variables are not inputs
-  check('Math.pi', {
+  await check('Math.pi', {
     inputs: [],
     outputs: [{}]
   })
-  check('const foo = require("foo")\nfoo.bar', {
+
+  await check('const foo = require("foo")\nfoo.bar', {
     inputs: [],
     outputs: [{}]
   })
 
   // Non-global, undeclared variables are inputs
-  check('const result = specialFunc()', {
+  await check('const result = specialFunc()', {
     inputs: [{name: 'specialFunc'}],
     outputs: [{name: 'result'}]
   })
-  check('specialMath.pi', {
+
+  await check('specialMath.pi', {
     inputs: [{name: 'specialMath'}],
     outputs: [{}]
   })
 
   // Last statement is an undeclared variable
-  check('foo', {
+  await check('foo', {
     inputs: [{name: 'foo'}],
     outputs: [{name: 'foo'}]
   })
 
   // Last statement is a declaration
 
-  check('var foo', {
+  await check('var foo', {
     inputs: [],
     outputs: [{name: 'foo'}]
   })
 
-  check('const foo = 1', {
+  await check('const foo = 1', {
     inputs: [],
     outputs: [{name: 'foo'}]
   })
 
   // Last statement is name of locally declared variable
 
-  check('var foo\nfoo', {
+  await check('var foo\nfoo', {
     inputs: [],
     outputs: [{name: 'foo'}]
   })
 
-  check('let foo\nfoo', {
+  await check('let foo\nfoo', {
     inputs: [],
     outputs: [{name: 'foo'}]
   })
 
-  check('const foo = 1\nfoo', {
+  await check('const foo = 1\nfoo', {
     inputs: [],
     outputs: [{name: 'foo'}]
   })
 
-  check('var foo = 1\nfoo', {
+  await check('var foo = 1\nfoo', {
     inputs: [],
     outputs: [{name: 'foo'}]
   })
 
   // Last statement is a declaration with multiple declarations (first identifier used)
-  check('foo\nbar\nlet baz, urg\n\n', {
+  await check('foo\nbar\nlet baz, urg\n\n', {
     inputs: [{name: 'foo'}, {name: 'bar'}],
     outputs: [{name: 'baz'}]
   })
 
   // Last statement is not a declaration or identifier
-  check('let foo\n{bar\nlet baz}', {
+  await check('let foo\n{bar\nlet baz}', {
     inputs: [{name: 'bar'}],
     outputs: []
   })
 
   // Last statement is not a declaration or identifier
-  check('let foo\nbar\nlet baz\ntrue', {
+  await check('let foo\nbar\nlet baz\ntrue', {
     inputs: [{name: 'bar'}],
     outputs: [{}]
   })
 
   // Variable declaration after usage (this will be a runtime error but this tests static analysis of code regardless)
-  check('foo\nlet foo\n', {
+  await check('foo\nlet foo\n', {
     inputs: [{name: 'foo'}],
     outputs: [{name: 'foo'}]
   })
 
   // Last statement is an expression (producing an unnamed output)
 
-  check('true', {
+  await check('true', {
     inputs: [],
     outputs: [{}]
   })
 
-  check('foo * 3', {
+  await check('foo * 3', {
     inputs: [{name: 'foo'}],
     outputs: [{}]
   })
 
-  check('var foo = 1\nfoo * 3', {
+  await check('var foo = 1\nfoo * 3', {
     inputs: [],
+    outputs: [{}]
+  })
+
+  await check('let z = x * y;\n(z * 2)', {
+    inputs: [{name: 'x'}, {name: 'y'}],
     outputs: [{}]
   })
 
   assert.end()
 })
 
-testAsync('JsContext.compile expression', async assert => {
+testAsync('JavascriptContext.compile expression', async assert => {
   let context = new JavascriptContext()
 
   async function check (source, expected) {
@@ -175,43 +182,43 @@ testAsync('JsContext.compile expression', async assert => {
     )
   }
 
-  check('42', {
+  await check('42', {
     inputs: [],
     outputs: [{}],
     messages: []
   })
 
-  check('x * 3', {
+  await check('x * 3', {
     inputs: [{name: 'x'}],
     outputs: [{}],
     messages: []
   })
 
-  check('let y = x * 3', {
+  await check('let y = x * 3', {
     inputs: [],
     outputs: [],
     messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
   })
 
-  check('y = x * 3', {
+  await check('y = x * 3', {
     inputs: [],
     outputs: [],
     messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
   })
 
-  check('x++', {
+  await check('x++', {
     inputs: [],
     outputs: [],
     messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
   })
 
-  check('y--', {
+  await check('y--', {
     inputs: [],
     outputs: [],
     messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
   })
 
-  check('function foo(){}', {
+  await check('function foo(){}', {
     inputs: [],
     outputs: [],
     messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
@@ -260,21 +267,21 @@ testAsync('JavascriptContext.compile function', async assert => {
     assert.deepEqual(params, expect, message)
   }
 
-  checkParams('function func (){}', undefined, 'no parameters')
-  checkParams('function func (a){}', [{name: 'a'}], 'one parameter')
-  checkParams('function func (a, b, c){}', [{name: 'a'}, {name: 'b'}, {name: 'c'}], 'three parameters')
+  await checkParams('function func (){}', undefined, 'no parameters')
+  await checkParams('function func (a){}', [{name: 'a'}], 'one parameter')
+  await checkParams('function func (a, b, c){}', [{name: 'a'}, {name: 'b'}, {name: 'c'}], 'three parameters')
 
-  checkParams('function func (...a){}', [{name: 'a', repeats: true}], 'one repeatable parameters')
+  await checkParams('function func (...a){}', [{name: 'a', repeats: true}], 'one repeatable parameters')
 
-  checkParams('function func (___a){}', [{name: 'a', extends: true}], 'one extensible parameters')
+  await checkParams('function func (___a){}', [{name: 'a', extends: true}], 'one extensible parameters')
 
   // Currently, do not attempt to parse parameter defaults into values
-  checkParams('function func (a=1){}', [{name: 'a', default: '1'}], 'a parameter with a number default')
-  checkParams('function func (a="foo"){}', [{name: 'a', default: '"foo"'}], 'a parameter with a number default')
-  checkParams('function func (a=[1, 2, 3]){}', [{name: 'a', default: '[1, 2, 3]'}], 'a parameter with an array default')
-  checkParams('function func (a={b:1, c:2}){}', [{name: 'a', default: '{b:1, c:2}'}], 'a parameter with an array default')
+  await checkParams('function func (a=1){}', [{name: 'a', default: '1'}], 'a parameter with a number default')
+  await checkParams('function func (a="foo"){}', [{name: 'a', default: '"foo"'}], 'a parameter with a number default')
+  await checkParams('function func (a=[1, 2, 3]){}', [{name: 'a', default: '[1, 2, 3]'}], 'a parameter with an array default')
+  await checkParams('function func (a={b:1, c:2}){}', [{name: 'a', default: '{b:1, c:2}'}], 'a parameter with an array default')
 
-  checkParams(`
+  await checkParams(`
     /**
      * @param a Description of parameter a
      * @param {typeB} b Description of parameter b
@@ -285,7 +292,7 @@ testAsync('JavascriptContext.compile function', async assert => {
     {name: 'b', type: 'typeB', description: 'Description of parameter b'}
   ], 'parameter descriptions and types from docs')
 
-  checkParams(`
+  await checkParams(`
     /**
      * @param {...number} pars Description of parameters
      */
@@ -294,7 +301,7 @@ testAsync('JavascriptContext.compile function', async assert => {
     {name: 'pars', type: 'number', repeats: true, description: 'Description of parameters'}
   ], 'repeatable parameter with type specified and elipses')
 
-  checkParams(`
+  await checkParams(`
     /**
      * @param {___number} pars Description of parameters
      */
@@ -311,13 +318,13 @@ testAsync('JavascriptContext.compile function', async assert => {
     assert.deepEqual(return_, expect, message)
   }
 
-  checkReturn(
+  await checkReturn(
     `function func (){}`,
     undefined,
     'return can only come from doc comment'
   )
 
-  checkReturn(
+  await checkReturn(
     `
     /**
      * @return {typeReturn} Description of return
@@ -454,16 +461,76 @@ testAsync('JavascriptContext.compile function', async assert => {
   assert.end()
 })
 
-test('JavascriptContext.evaluateCall', async assert => {
+testAsync('JavascriptContext.execute', async assert => {
+  let context = new JavascriptContext()
+
+  async function check (source, inputs = [], output = undefined) {
+    for (let input of inputs) {
+      input.value = await context.pack(input.value)
+    }
+
+    const result = await context.execute({
+      type: 'cell',
+      source: {
+        type: 'string',
+        data: source
+      },
+      inputs: inputs
+    })
+
+    let outputs = output ? [output] : []
+    for (let output of outputs) {
+      output.value = await context.pack(output.value)
+    }
+
+    assert.deepEqual(result.outputs, outputs, source)
+  }
+
+  // No output
+  await check('')
+  await check('if(true){\n  let x = 4\n}\n')
+
+  // Output value but no name
+  await check('42', [], {value: 42})
+  await check('1.1 * 2', [], {value: 2.2})
+  await check('let x = 3\nMath.sqrt(x*3)', [], {value: 3})
+  await check('// Multiple lines and comments\nlet x = {}\nObject.assign(x, {\na:1\n})\n', [], {value: { a: 1 }})
+
+  // Output value and name
+  await check('let b = 1', [], {name: 'b', value: 1})
+  await check('let c = 1\nc', [], {name: 'c', value: 1})
+
+  // Inputs value and name
+  await check('x * 3', [{name: 'x', value: 6}], {value: 18})
+  await check('let z = x * y;\n(z * 2).toString()', [
+    {name: 'x', value: 2},
+    {name: 'y', value: 3}
+  ], {value: '12'})
+
+  assert.end()
+})
+
+testAsync('JavascriptContext.errors', async assert => {
+  let context = new JavascriptContext()
+
+  await context.execute({
+    type: 'cell',
+    source: {
+      type: 'string',
+      data: 'source'
+    },
+    inputs: []
+  })
+
+  assert.end()
+})
+
+testAsync('JavascriptContext.evaluateCall', async assert => {
   let context = new JavascriptContext()
 
   async function testCall (call, expect, message) {
-    try {
-      let result = await context.evaluateCall(call)
-      assert.deepEqual(result.value, expect, message)
-    } catch (error) {
-      console.log(error)
-    }
+    let result = await context.evaluateCall(call)
+    assert.deepEqual(result.value, expect, message)
   }
 
   async function testCallThrows (call, expect, message) {
@@ -480,7 +547,7 @@ test('JavascriptContext.evaluateCall', async assert => {
   }
   await context.execute(no_pars)
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'no_pars'}
@@ -491,7 +558,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'no_pars()'
   )
 
-  testCallThrows(
+  await testCallThrows(
     {
       type: 'call',
       func: {type: 'get', name: 'no_pars'},
@@ -508,7 +575,7 @@ test('JavascriptContext.evaluateCall', async assert => {
   }
   await context.execute(one_par)
 
-  testCallThrows(
+  await testCallThrows(
     {
       type: 'call',
       func: {type: 'get', name: 'one_par'}
@@ -516,7 +583,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'Function parameter "par" must be supplied'
   )
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'one_par'},
@@ -530,7 +597,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'one_par(1)'
   )
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'one_par'},
@@ -544,7 +611,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'one_par(par=1)'
   )
 
-  testCallThrows(
+  await testCallThrows(
     {
       type: 'call',
       func: {type: 'get', name: 'one_par'},
@@ -559,7 +626,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'one_par(1, par=2)'
   )
 
-  testCallThrows(
+  await testCallThrows(
     {
       type: 'call',
       func: {type: 'get', name: 'one_par'},
@@ -578,7 +645,7 @@ test('JavascriptContext.evaluateCall', async assert => {
   }
   await context.execute(three_pars)
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'three_pars'},
@@ -599,7 +666,7 @@ test('JavascriptContext.evaluateCall', async assert => {
   }
   await context.execute(default_par)
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'default_par'},
@@ -614,7 +681,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'default_par("beep", "bop")'
   )
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'default_par'},
@@ -633,7 +700,7 @@ test('JavascriptContext.evaluateCall', async assert => {
   }
   await context.execute(repeats_par)
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'repeats_par'},
@@ -649,7 +716,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'repeats_par("bar", "baz", "boop")'
   )
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'repeats_par'},
@@ -668,7 +735,7 @@ test('JavascriptContext.evaluateCall', async assert => {
   }
   await context.execute(extends_par)
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'extends_par'},
@@ -682,7 +749,7 @@ test('JavascriptContext.evaluateCall', async assert => {
     'extends_par(1)'
   )
 
-  testCall(
+  await testCall(
     {
       type: 'call',
       func: {type: 'get', name: 'extends_par'},

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -230,16 +230,16 @@ testAsync('JavascriptContext.compile expression', async assert => {
 testAsync('JavascriptContext.compile function', async assert => {
   let context = new JavascriptContext()
 
-  function afunc () {}
+  function afunc (x, y) { return x * y }
   assert.deepEqual(
     await context.compile(afunc),
     {
       type: 'cell',
       source: {
         type: 'string',
-        data: 'function afunc() {}'
+        data: 'function afunc(x, y) { return x * y }'
       },
-      inputs: [],
+      inputs: [ { name: 'x' }, { name: 'y' } ],
       outputs: [{
         name: 'afunc',
         value: {
@@ -248,8 +248,12 @@ testAsync('JavascriptContext.compile function', async assert => {
             type: 'function',
             name: 'afunc',
             methods: {
-              'afunc()': {
-                signature: 'afunc()'
+              'afunc(x, y)': {
+                signature: 'afunc(x, y)',
+                params: [
+                  {name: 'x'},
+                  {name: 'y'}
+                ]
               }
             }
           }

--- a/test/contexts/JavascriptContext.test.js
+++ b/test/contexts/JavascriptContext.test.js
@@ -139,6 +139,69 @@ testAsync('JavascriptContext.compile', async assert => {
   assert.end()
 })
 
+testAsync('JsContext.compile expression', async assert => {
+  let context = new JavascriptContext()
+
+  async function check (source, expected) {
+    const result = await context.compile({
+      source: {
+        type: 'string',
+        data: source
+      },
+      expr: true
+    })
+    assert.deepEqual(
+      (({inputs, outputs, messages}) => ({inputs, outputs, messages}))(result),
+      expected,
+      source
+    )
+  }
+
+  check('42', {
+    inputs: [],
+    outputs: [{}],
+    messages: []
+  })
+
+  check('x * 3', {
+    inputs: [{name: 'x'}],
+    outputs: [{}],
+    messages: []
+  })
+
+  check('let y = x * 3', {
+    inputs: [],
+    outputs: [],
+    messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
+  })
+
+  check('y = x * 3', {
+    inputs: [],
+    outputs: [],
+    messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
+  })
+
+  check('x++', {
+    inputs: [],
+    outputs: [],
+    messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
+  })
+
+  check('y--', {
+    inputs: [],
+    outputs: [],
+    messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
+  })
+
+  check('function foo(){}', {
+    inputs: [],
+    outputs: [],
+    messages: [{ type: 'error', message: 'Cell source code must be a single, simple Javascript expression' }]
+  })
+
+  assert.end()
+})
+
 testAsync('JavascriptContext.compile function', async assert => {
   let context = new JavascriptContext()
 

--- a/test/contexts/NodeContext.test.js
+++ b/test/contexts/NodeContext.test.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const test = require('tape')
 
+const { testAsync } = require('../helpers')
 const NodeContext = require('../../lib/contexts/NodeContext')
 
 test('NodeContext', assert => {
@@ -11,7 +12,7 @@ test('NodeContext', assert => {
   assert.end()
 })
 
-test('NodeContext.compileLibrary', async assert => {
+testAsync('NodeContext.compileLibrary', async assert => {
   const context = new NodeContext()
   const libtest = path.join(__dirname, 'fixtures', 'libtest')
 
@@ -29,7 +30,7 @@ test('NodeContext.compileLibrary', async assert => {
   assert.end()
 })
 
-test('NodeContext.executeLibrary', async assert => {
+testAsync('NodeContext.executeLibrary', async assert => {
   const context = new NodeContext()
   const libtest = path.join(__dirname, 'fixtures', 'libtest')
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,27 @@
 const test = require('tape')
 
 /**
+ * Test an async function
+ *
+ * A convienience function that provides for consistent
+ * handling of errors when testing async funcions
+ *
+ * @param  {String} name Name of test
+ * @param  {Function} func Async test function
+ */
+var testAsync = (name, func) => {
+  test(name, async assert => {
+    try {
+      await func(assert)
+    } catch(error) {
+      assert.fail(error.message)
+      console.log(error.stack) // eslint-disable-line
+      assert.end()
+    }
+  })
+}
+
+/**
  * Test a promise
  *
  * A convienience function that provides for consistent
@@ -20,5 +41,6 @@ var testPromise = (name, func) => {
 }
 
 module.exports = {
+  testAsync,
   testPromise
 }


### PR DESCRIPTION
The `JavascriptContext` handles functions but nothing else. `stencila/stencila/JsContext` handles everything except functions. We need to merge the functionality into one.

See https://github.com/stencila/stencila/pull/638#issuecomment-386527149