### PR TITLE
Fix spawnPeer

### DIFF
--- a/lib/host/Host.js
+++ b/lib/host/Host.js
@@ -727,12 +727,18 @@ class Host {
    * @param  {Object} peer A peer object including `manifest`
    * @return {[type]}      [description]
    */
-  async spawnPeer (peer) {
-    let spawn = peer.manifest.spawn
-    let child = execa(spawn[0], spawn.slice(1))
-    child.stdout.on('data', data => {
-      const result = JSON.parse(data)
-      this.registerPeer(result)
+  spawnPeer (peer) {
+    return new Promise((resolve, reject) => {
+      let spawn = peer.manifest.spawn
+      let child = execa(spawn[0], spawn.slice(1))
+      child.stdout.on('data', data => {
+        const spawnedPeer = JSON.parse(data)
+        this.registerPeer(spawnedPeer)
+        resolve(spawnedPeer)
+      })
+      child.catch(error => {
+        reject(new Error(`Could not spawn peer using "${spawn.join(' ')}": ${error.message}`))
+      })
     })
   }
 


### PR DESCRIPTION
This fixes the spawning of peers. We've had this before but without the additional layer of security currently provided by the shared secret key. Ensuring this works so the next release of Stencila desktops can seemlessly of R and Python contexts e.g.

![foo](https://user-images.githubusercontent.com/1152336/39799048-eb29745a-53b6-11e8-9c7c-58c6eda68d99.png)

@apawlik : getting closer to easier setup for R :)